### PR TITLE
Improve benchmark UI and settings for consistency

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -10,6 +10,9 @@ var exclude_benchmarks_glob := ""
 func _ready() -> void:
 	# Use a fixed random seed to improve reproducibility of results.
 	seed(0x60d07)
+	
+	# No point in copying JSON without any results yet.
+	$CopyJSON.visible = false
 
 	tree.columns = 6
 	tree.set_column_titles_visible(true)
@@ -42,6 +45,8 @@ func _ready() -> void:
 		item.set_meta("path", path)
 
 		if results:
+			$CopyJSON.visible = true
+
 			if results.render_cpu:
 				item.set_text(1, "%s ms" % str(results.render_cpu).pad_decimals(2))
 			if results.render_gpu:
@@ -117,14 +122,12 @@ func _on_Run_pressed() -> void:
 		if item.is_checked(0):
 			queue.push_back(index)
 			paths.push_back(path)
-			print(queue)
 
 		index += 1
 
 	if index >= 1:
 		print_rich("[b]Running %d benchmarks:[/b] %s " % [queue.size(), ", ".join(paths)])
-
-		Manager.benchmark(queue, $TestTime.value, "res://main.tscn")
+		Manager.benchmark(queue, "res://main.tscn")
 	else:
 		print_rich("[color=red][b]ERROR:[/b] No benchmarks to run.[/color]")
 		if Manager.run_from_cli:

--- a/main.tscn
+++ b/main.tscn
@@ -8,83 +8,77 @@ anchor_bottom = 1.0
 script = ExtResource("1")
 
 [node name="Label" type="Label" parent="."]
-offset_left = 24.0
-offset_top = 12.0
-offset_right = 197.0
-offset_bottom = 52.0
-theme_override_font_sizes/font_size = 16
+offset_left = 20.0
+offset_top = 10.0
+offset_right = 285.0
+offset_bottom = 48.0
 text = "Available Benchmarks:"
+vertical_alignment = 1
 
 [node name="Tree" type="Tree" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 24.0
-offset_top = 40.0
-offset_right = -18.0
-offset_bottom = -45.0
+offset_left = 10.0
+offset_top = 56.0
+offset_right = -10.0
+offset_bottom = -74.0
+grow_horizontal = 2
+grow_vertical = 2
 hide_root = true
+metadata/_edit_layout_mode = 1
 
 [node name="SelectAll" type="Button" parent="."]
-anchor_left = 1.0
 anchor_top = 1.0
-anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -592.0
-offset_top = -38.0
-offset_right = -510.0
+offset_left = 10.0
+offset_top = -66.0
+offset_right = 158.0
 offset_bottom = -9.0
+grow_vertical = 0
 text = "Select All"
+metadata/_edit_layout_mode = 1
 
 [node name="SelectNone" type="Button" parent="."]
-anchor_left = 1.0
 anchor_top = 1.0
-anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -499.0
-offset_top = -38.0
-offset_right = -396.0
+offset_left = 184.0
+offset_top = -66.0
+offset_right = 365.0
 offset_bottom = -9.0
+grow_vertical = 0
 text = "Select None"
+metadata/_edit_layout_mode = 1
 
 [node name="CopyJSON" type="Button" parent="."]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -344.0
-offset_top = -38.0
-offset_right = -153.0
+offset_left = -542.0
+offset_top = -66.0
+offset_right = -224.0
 offset_bottom = -9.0
-text = "Copy JSON to clipboard"
+grow_horizontal = 0
+grow_vertical = 0
+text = "Copy JSON to Clipboard"
+metadata/_edit_layout_mode = 1
 
 [node name="Run" type="Button" parent="."]
 anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -109.0
-offset_top = -41.0
-offset_right = -27.0
-offset_bottom = -7.0
-theme_override_font_sizes/font_size = 20
+offset_left = -182.0
+offset_top = -66.0
+offset_right = -11.0
+offset_bottom = -9.0
+grow_horizontal = 0
+grow_vertical = 0
+theme_override_font_sizes/font_size = 30
 disabled = true
 text = "Run
 "
-
-[node name="Label2" type="Label" parent="."]
-offset_left = 35.0
-offset_top = 563.0
-offset_right = 155.0
-offset_bottom = 603.0
-text = "Test Time (sec)"
-
-[node name="TestTime" type="SpinBox" parent="."]
-offset_left = 160.0
-offset_top = 560.0
-offset_right = 342.0
-offset_bottom = 593.0
-min_value = 1.0
-value = 5.0
+metadata/_edit_layout_mode = 1
 
 [connection signal="item_edited" from="Tree" to="." method="_on_Tree_item_edited"]
 [connection signal="pressed" from="SelectAll" to="." method="_on_SelectAll_pressed"]

--- a/manager.gd
+++ b/manager.gd
@@ -124,7 +124,7 @@ func get_test_path(index: int) -> String:
 	return tests[index].path
 
 
-func benchmark(queue: Array, time: float, return_path: String) -> void:
+func benchmark(queue: Array, return_path: String) -> void:
 	tests_queue = queue
 	if tests_queue.size() == 0:
 		return
@@ -132,7 +132,8 @@ func benchmark(queue: Array, time: float, return_path: String) -> void:
 	if tests_queue_initial_size == 0:
 		tests_queue_initial_size = queue.size()
 
-	test_time = time
+	# Run benchmarks for 5 seconds if they have a time limit.
+	test_time = 5.0
 	return_to_scene = return_path
 	begin_test()
 

--- a/project.godot
+++ b/project.godot
@@ -28,3 +28,13 @@ config/icon="res://icon.png"
 [autoload]
 
 Manager="*res://manager.gd"
+
+[display]
+
+window/size/viewport_width=1920
+window/size/viewport_height=1080
+window/stretch/mode="viewport"
+
+[gui]
+
+theme/default_theme_scale=1.5


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot-benchmarks/pull/12 (can be merged independently).

- Use a fixed 1920×1080 viewport size for consistent results.
  - `--resolution` CLI argument can be used to override this if needed. It may be a good idea to note the window size in the results JSON too.
- Hardcode the benchmark duration to 5 seconds for benchmarks that have a time limit for consistent results.
  - We can consider adding a CLI argument to override this if needed (also noting the value in the results JSON).
- Move the Select All and Select None button next to the "Available Benchmarks:" label, as they're closer to the checkboxes this way.
- Make buttons larger to be easier to click.
- Only show the Copy JSON to Clipboard button after running benchmarks.