### PR TITLE
Add Polygon2D benchmarks

### DIFF
--- a/benchmarks/rendering/polygon_2d/1000_polygon_2d.gd
+++ b/benchmarks/rendering/polygon_2d/1000_polygon_2d.gd
@@ -1,0 +1,7 @@
+extends "res://benchmarks/rendering/polygon_2d/polygon_2d_base.gd"
+
+const NUMBER_OF_POLYGONS := 1000
+
+
+func _ready() -> void:
+	fill_with_polygons(NUMBER_OF_POLYGONS)

--- a/benchmarks/rendering/polygon_2d/1000_polygon_2d.tscn
+++ b/benchmarks/rendering/polygon_2d/1000_polygon_2d.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://ch84o31eohli0"]
+
+[ext_resource type="Script" path="res://benchmarks/rendering/polygon_2d/1000_polygon_2d.gd" id="1_4vuxe"]
+[ext_resource type="Script" path="res://benchmark.gd" id="1_evy4a"]
+
+[node name="Node2D" type="Node2D"]
+script = ExtResource("1_4vuxe")
+
+[node name="Benchmark" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 34.0
+script = ExtResource("1_evy4a")
+test_render_cpu = true
+test_render_gpu = true
+
+[node name="Camera2D" type="Camera2D" parent="."]

--- a/benchmarks/rendering/polygon_2d/100_polygon_2d.gd
+++ b/benchmarks/rendering/polygon_2d/100_polygon_2d.gd
@@ -1,0 +1,7 @@
+extends "res://benchmarks/rendering/polygon_2d/polygon_2d_base.gd"
+
+const NUMBER_OF_POLYGONS := 100
+
+
+func _ready() -> void:
+	fill_with_polygons(NUMBER_OF_POLYGONS)

--- a/benchmarks/rendering/polygon_2d/100_polygon_2d.tscn
+++ b/benchmarks/rendering/polygon_2d/100_polygon_2d.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://baaw7jdfbtm21"]
+
+[ext_resource type="Script" path="res://benchmarks/rendering/polygon_2d/100_polygon_2d.gd" id="1_26bs8"]
+[ext_resource type="Script" path="res://benchmark.gd" id="1_64c3n"]
+
+[node name="Node2D" type="Node2D"]
+script = ExtResource("1_26bs8")
+
+[node name="Benchmark" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 34.0
+script = ExtResource("1_64c3n")
+test_render_cpu = true
+test_render_gpu = true
+
+[node name="Camera2D" type="Camera2D" parent="."]

--- a/benchmarks/rendering/polygon_2d/10_polygon_2d.gd
+++ b/benchmarks/rendering/polygon_2d/10_polygon_2d.gd
@@ -1,0 +1,7 @@
+extends "res://benchmarks/rendering/polygon_2d/polygon_2d_base.gd"
+
+const NUMBER_OF_POLYGONS := 10
+
+
+func _ready() -> void:
+	fill_with_polygons(NUMBER_OF_POLYGONS)

--- a/benchmarks/rendering/polygon_2d/10_polygon_2d.tscn
+++ b/benchmarks/rendering/polygon_2d/10_polygon_2d.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=3 uid="uid://3tlrhlepn5um"]
+
+[ext_resource type="Script" path="res://benchmark.gd" id="1_51qmg"]
+[ext_resource type="Script" path="res://benchmarks/rendering/polygon_2d/10_polygon_2d.gd" id="1_kcy1r"]
+
+[node name="Node2D" type="Node2D"]
+script = ExtResource("1_kcy1r")
+
+[node name="Benchmark" type="Label" parent="."]
+offset_right = 40.0
+offset_bottom = 34.0
+script = ExtResource("1_51qmg")
+test_render_cpu = true
+test_render_gpu = true
+
+[node name="Camera2D" type="Camera2D" parent="."]

--- a/benchmarks/rendering/polygon_2d/_polygon_2d.tscn
+++ b/benchmarks/rendering/polygon_2d/_polygon_2d.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://bgrrel3janaoj"]
+
+[node name="Polygon2D" type="Polygon2D"]

--- a/benchmarks/rendering/polygon_2d/polygon_2d_base.gd
+++ b/benchmarks/rendering/polygon_2d/polygon_2d_base.gd
@@ -1,0 +1,28 @@
+extends Node2D
+
+var Polygon := preload("res://benchmarks/rendering/polygon_2d/_polygon_2d.tscn") as PackedScene
+var polygons := []
+var polygon_xforms := []
+
+func fill_with_polygons(polygon_amount: int) -> void:
+	var cam := $Camera2D as Camera2D
+	var ss := get_tree().root.size
+	var center := cam.get_screen_center_position()
+	for polygon in polygon_amount:
+		var xf := Transform2D()
+		xf.origin = Vector2(center.x + randf() * ss.x, center.y + randf() * ss.y)
+		var new_polygon = Polygon.instantiate() as Polygon2D
+		var vertices := PackedVector2Array()
+		var p_scale = randf_range(30,50)
+		for i in 32:
+			vertices.append(Vector2(p_scale*cos(i * PI / 16),p_scale*sin(i * PI / 16)))
+		new_polygon.polygon = vertices
+		call_deferred("add_child", new_polygon)
+		new_polygon.set_global_transform(xf)
+
+		polygons.append(new_polygon)
+		polygon_xforms.append(xf)
+
+func _exit_tree() -> void:
+	for polygon in polygons:
+		polygon.queue_free()


### PR DESCRIPTION
Part of #11. Instantiates either 10, 100, or 1000 Polygon2D's, depending on the benchmark. The polygons are randomly scaled and have 32 vertices.