### PR TITLE
Fix incorrect positioning of objects in some benchmarks

### DIFF
--- a/benchmarks/rendering/culling.gd
+++ b/benchmarks/rendering/culling.gd
@@ -64,7 +64,7 @@ class TestScene extends Node3D:
 
 		var zn := 2
 		var zextent := cam.far - zn
-		var ss := get_tree().root.size
+		var ss := get_tree().root.get_visible_rect().size
 		var from := cam.project_position(Vector2(0, ss.y), zextent)
 		var extents := cam.project_position(Vector2(ss.x, 0), zextent) - from
 
@@ -82,7 +82,7 @@ class TestScene extends Node3D:
 	func do_fill_with_omni_lights() -> void:
 		var zn := 2
 		var zextent := cam.far - zn
-		var ss := get_tree().root.size
+		var ss := get_tree().root.get_visible_rect().size
 		var from := cam.project_position(Vector2(0,ss.y),zextent)
 		var extents := cam.project_position(Vector2(ss.x,0),zextent) - from
 

--- a/benchmarks/rendering/polygon_2d.gd
+++ b/benchmarks/rendering/polygon_2d.gd
@@ -16,11 +16,10 @@ class TestScene extends Node2D:
 		add_child(cam)
 
 	func _ready() -> void:
-		var ss := get_tree().root.size
-		var center := cam.get_screen_center_position()
+		var ss := get_tree().root.get_visible_rect().size
 		for i in instance_amount:
 			var xf := Transform2D()
-			xf.origin = Vector2(center.x + randf() * ss.x, center.y + randf() * ss.y)
+			xf.origin = Vector2(randf_range(-ss.x, ss.x), randf_range(-ss.y, ss.y)) / 2.0
 
 			var new_instance := create_instance()
 


### PR DESCRIPTION
`get_tree().root.size` was returning the window dimensions, presumably the intent was to use the viewport dimensions `get_tree().root.get_visible_rect().size`

Also fixes polygon_2d scenes being off center.