### PR TITLE
Add `--run-while` option to control benchmark runtime

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ For more advanced benchmarks, the runtime expects the function to return a `Node
 Return the appropriate node for your benchmark[^1] to signal to the runtime
 that it should continue measuring system resource usage even after your function returns.
 The runtime will add your node to the scene as a root node,
-leave it running for a fixed amount of time (currently 5 seconds),
+leave it running for the given duration (default 5 seconds),
 and then end the benchmark and report the various metrics configured above.
 
 [^1]: For 3D rendering benchmarks, the root node should be Node3D. For 2D

--- a/README.md
+++ b/README.md
@@ -72,10 +72,26 @@ Use glob syntax (with `*` acting as a wildcard) to run a category of benchmarks:
 You can exclude specific benchmarks using the `--exclude-benchmarks` command line argument.
 This argument also supports globbing and can be used at the same time as `--include-benchmarks`.
 
+#### Benchmark runtime
+
+You can use the `--run-while` argument to manage the runtime of benchmarks where this is relevant.
+Benchmarks that involve a scene will run continuously until the provided
+[Expression](https://docs.godotengine.org/en/stable/classes/class_expression.html)
+returns false.
+
+Usage examples:
+
+- `--run-while="time < 1.0"`: Run each benchmark for 1 second
+- `--run-while="frame < 10"`: Run each benchmark for 10 frames
+- `--run-while="frame < 100 and time < 5.0"`: Run each benchmark for 100 frames with a 5 second timeout
+- `--run-while=false`: Do nothing (dry run)
+
+If unspecified, the default value is `--run-while="time < 5.0"`.
+
 #### Results
 
 For each benchmark, the project will track how long the main thread spent setting up the scene,
-then run the scene for five seconds and log the average per-frame statistics.
+then run the scene for the duration given above and log the average per-frame statistics.
 (All times given are in milliseconds. Lower values are better.)
 
 - **Render CPU:** Average CPU time spent rendering each frame (such as setting up draw calls).

--- a/main.gd
+++ b/main.gd
@@ -9,6 +9,7 @@ var arg_include_benchmarks := ""
 var arg_exclude_benchmarks := ""
 var arg_save_json := ""
 var arg_run_benchmarks := false
+var arg_run_while := "time < 5.0"
 
 @onready var tree := $Tree as Tree
 
@@ -127,7 +128,14 @@ func _on_Run_pressed() -> void:
 		# Automatically exit after running benchmarks for automation purposes.
 		if not arg_run_benchmarks:
 			return_path = get_tree().current_scene.scene_file_path
-		Manager.benchmark(test_ids, return_path)
+		var run_while_expr := Expression.new()
+		var err := run_while_expr.parse(arg_run_while, ["time", "frame"])
+		if err == OK:
+			Manager.benchmark(test_ids, return_path, run_while_expr)
+		else:
+			print("Error in expression: " + arg_run_while)
+			print(run_while_expr.get_error_text())
+			get_tree().quit(1)
 	else:
 		print_rich("[color=red][b]ERROR:[/b] No benchmarks to run.[/color]")
 		if arg_run_benchmarks:


### PR DESCRIPTION
Broken out from #27 now that the functionality of both `--run-frames` and `--run-seconds` (from an earlier iteration) have been subsumed into a single argument, removing the need to choose between one or the other.

---

### Benchmark runtime

You can use the `--run-while` argument to manage the runtime of benchmarks where this is relevant. Benchmarks that involve a scene will run continuously until the provided [Expression](https://docs.godotengine.org/en/stable/classes/class_expression.html) returns false.

Usage examples:

- `--run-while="time < 1.0"`: Run each benchmark for 1 second
- `--run-while="frame < 10"`: Run each benchmark for 10 frames
- `--run-while="frame < 100 and time < 5.0"`: Run each benchmark for 100 frames with a 5 second timeout
- `--run-while=false`: Do nothing (dry run)

If unspecified, the default value is `--run-while="time < 5.0"`.