### PR TITLE
Implement Core benchmarks

### DIFF
--- a/benchmarks/core/config_file.gd
+++ b/benchmarks/core/config_file.gd
@@ -1,0 +1,33 @@
+extends Benchmark
+
+const NUM_VALUES := 1000
+const ITERATIONS := 50
+const CONFIG_FILE := "user://BenchmarkConfigFile.cfg"
+const CONFIG_FILE_ENCRYTED := "user://BenchmarkEncryptedConfigFile.cfg"
+var config: ConfigFile = ConfigFile.new()
+
+func _init() -> void:
+	create_config_file()
+	config.save(CONFIG_FILE)
+	config.save_encrypted_pass(CONFIG_FILE_ENCRYTED, "PasswordIsGodot")
+
+func create_config_file() -> void:
+	for i in 1000:
+		config.set_value("Sec" + str(i % 10), "Key" + str(i), "Val" + str(i))
+
+func benchmark_save() -> void:
+	for i in ITERATIONS:
+		config.save(CONFIG_FILE)
+
+func benchmark_load() -> void:
+	for i in ITERATIONS:
+		config.load(CONFIG_FILE)
+
+func benchmark_save_with_password() -> void:
+	for i in ITERATIONS:
+		config.save_encrypted_pass(CONFIG_FILE_ENCRYTED, "PasswordIsGodot")
+
+func benchmark_load_with_password() -> void:
+	for i in ITERATIONS:
+		config.load_encrypted_pass(CONFIG_FILE_ENCRYTED, "PasswordIsGodot")
+

--- a/benchmarks/core/config_file.gd
+++ b/benchmarks/core/config_file.gd
@@ -11,21 +11,26 @@ func _init() -> void:
 	config.save(CONFIG_FILE)
 	config.save_encrypted_pass(CONFIG_FILE_ENCRYPTED, "PasswordIsGodot")
 
+
 func create_config_file() -> void:
 	for i in 1000:
 		config.set_value("Sec" + str(i % 10), "Key" + str(i), "Val" + str(i))
+
 
 func benchmark_save() -> void:
 	for i in ITERATIONS:
 		config.save(CONFIG_FILE)
 
+
 func benchmark_load() -> void:
 	for i in ITERATIONS:
 		config.load(CONFIG_FILE)
 
+
 func benchmark_save_with_password() -> void:
 	for i in ITERATIONS:
 		config.save_encrypted_pass(CONFIG_FILE_ENCRYPTED, "PasswordIsGodot")
+
 
 func benchmark_load_with_password() -> void:
 	for i in ITERATIONS:

--- a/benchmarks/core/config_file.gd
+++ b/benchmarks/core/config_file.gd
@@ -2,14 +2,14 @@ extends Benchmark
 
 const NUM_VALUES := 1000
 const ITERATIONS := 50
-const CONFIG_FILE := "user://BenchmarkConfigFile.cfg"
-const CONFIG_FILE_ENCRYTED := "user://BenchmarkEncryptedConfigFile.cfg"
+const CONFIG_FILE := "user://benchmark_config_file.ini"
+const CONFIG_FILE_ENCRYPTED := "user://benchmark_config_file.ini.encrypted"
 var config: ConfigFile = ConfigFile.new()
 
 func _init() -> void:
 	create_config_file()
 	config.save(CONFIG_FILE)
-	config.save_encrypted_pass(CONFIG_FILE_ENCRYTED, "PasswordIsGodot")
+	config.save_encrypted_pass(CONFIG_FILE_ENCRYPTED, "PasswordIsGodot")
 
 func create_config_file() -> void:
 	for i in 1000:
@@ -25,9 +25,9 @@ func benchmark_load() -> void:
 
 func benchmark_save_with_password() -> void:
 	for i in ITERATIONS:
-		config.save_encrypted_pass(CONFIG_FILE_ENCRYTED, "PasswordIsGodot")
+		config.save_encrypted_pass(CONFIG_FILE_ENCRYPTED, "PasswordIsGodot")
 
 func benchmark_load_with_password() -> void:
 	for i in ITERATIONS:
-		config.load_encrypted_pass(CONFIG_FILE_ENCRYTED, "PasswordIsGodot")
+		config.load_encrypted_pass(CONFIG_FILE_ENCRYPTED, "PasswordIsGodot")
 

--- a/benchmarks/core/node_path.gd
+++ b/benchmarks/core/node_path.gd
@@ -1,0 +1,7 @@
+extends Benchmark
+
+const ITERATIONS = 1_000_000
+
+func benchmark_create() -> void:
+	for i in ITERATIONS:
+		var _n: NodePath = "Godot"

--- a/benchmarks/core/string_name.gd
+++ b/benchmarks/core/string_name.gd
@@ -1,0 +1,7 @@
+extends Benchmark
+
+const ITERATIONS = 1_000_000
+
+func benchmark_create() -> void:
+	for i in ITERATIONS:
+		var _s: StringName = "Godot"


### PR DESCRIPTION
Implements the following benchmarks in the `Core` section from #36  : 

🟪Algorithm🟪 StringNames: Creating and freeing 1000 StringNames
🟪Algorithm🟪 NodePaths: Creating and freeing 1000 NodePaths
~~🟪Algorithm🟪 Strings: Create a benchmark that runs all complex search/merge/etc string operations 50 times.~~
🟪Algorithm🟪 ConfigFileSave / ConfigFileLoad: Create a ConfigFile full of fields and sections (1000). Benchmark saving and benchmark loading.

NB: 1000 iterations for `NodePath` and `StringName` was too small and insignificant, so I bumped that up to 1M.

**Edit**: I did create a `string_manipulation.gd` in the `core` dir that tests most `String` methods, but it turns out, it was already done in the `gdscript` directory. So I removed mine, thus the strikethrough above.