### PR TITLE
Fix Crypto benchmark taking too long

### DIFF
--- a/benchmarks/core/crypto.gd
+++ b/benchmarks/core/crypto.gd
@@ -1,27 +1,31 @@
 extends Benchmark
 
-const ITERATIONS = 100_000
+const BYTES_SMALL = 100_000_000
+const BYTES = 1_000_000_000
 
 var crypto := Crypto.new()
 
-
-func benchmark_generate_10_random_bytes() -> void:
-	for i in ITERATIONS:
+func benchmark_generate_1m_random_bytes_10_at_a_time() -> void:
+	var iterations = BYTES_SMALL / 10
+	for i in iterations:
 		crypto.generate_random_bytes(10)
 
 
-func benchmark_generate_1k_random_bytes() -> void:
-	for i in ITERATIONS:
+func benchmark_generate_1g_random_bytes_1k_at_a_time() -> void:
+	var iterations = BYTES / 1000
+	for i in iterations:
 		crypto.generate_random_bytes(1000)
 
 
-func benchmark_generate_1m_random_bytes() -> void:
-	for i in ITERATIONS:
+func benchmark_generate_1g_random_bytes_1m_at_a_time() -> void:
+	var iterations = BYTES / 1_000_000
+	for i in iterations:
 		crypto.generate_random_bytes(1_000_000)
 
 
-func benchmark_generate_1g_random_bytes() -> void:
-	for i in ITERATIONS:
+func benchmark_generate_1g_random_bytes_at_once() -> void:
+	var iterations = BYTES / 1_000_000_000
+	for i in iterations:
 		crypto.generate_random_bytes(1_000_000_000)
 
 


### PR DESCRIPTION
`benchmark_generate_1g_random_bytes` takes way too long to finish (on my machine I aborted the benchmark after around 15 minutes so I don't know when/whether it would finish).
The reason: it generates 1G random bytes 100_000 times, which is obviously a bit too much.

I adjusted the random byte benchmarks and made their name more descriptive. All of them finish in 1500 - 3000ms on my machine now.

Revised benchmarks:
![grafik](https://github.com/godotengine/godot-benchmarks/assets/50084500/06801353-d649-4e84-9ff4-0c34711932cb)
