### PR TITLE
Implement scene nodes benchmarks

### DIFF
--- a/benchmarks/scene_nodes/add_children.gd
+++ b/benchmarks/scene_nodes/add_children.gd
@@ -1,0 +1,20 @@
+extends Benchmark
+
+const ITERATIONS = 50_000
+
+# Benchmark add_child by:
+# 1) Adding ITERATIONS children nodes without name
+# 2) Adding ITERATIONS children nodes with the same name
+
+func benchmark_add_children_without_name() -> void:
+	var root := Node.new()
+	for i in ITERATIONS:
+		root.add_child(Node.new())
+
+
+func benchmark_add_children_with_same_name() -> void:
+	var root := Node.new()
+	for i in ITERATIONS:
+		var node := Node.new()
+		node.set_name("name")
+		root.add_child(node)

--- a/benchmarks/scene_nodes/delete_children.gd
+++ b/benchmarks/scene_nodes/delete_children.gd
@@ -1,0 +1,46 @@
+extends Benchmark
+
+const ITERATIONS = 50_000
+
+var roots: Array[Node] = [ null, null, null ]
+var children: Array[Array] = [ [], [], [] ]
+
+# Benchmark remove_child by:
+# 1) Removing ITERATIONS children nodes in order
+# 2) Removing ITERATIONS children nodes in reverse order
+# 3) Removing ITERATIONS children nodes in random order
+# The different root-children pairs are stored in arrays since they need to be
+# created before the benchmark calls. Thus, the benchmarks use these pair indexes.
+# All trees are created in init.
+
+func _init() -> void:
+	create_trees()
+	children[1].reverse()
+	children[2].shuffle()
+
+
+func create_trees() -> void:
+	for i in roots.size():
+		roots[i] = Node.new()
+		for j in ITERATIONS:
+			roots[i].add_child(Node.new())
+		children[i] = roots[i].get_children()
+
+
+func benchmark_delete_children_in_order() -> void:
+	remove_children(0)
+
+
+func benchmark_delete_children_reverse_order() -> void:
+	remove_children(1)
+
+
+func benchmark_delete_children_random_order() -> void:
+	remove_children(2)
+
+
+func remove_children(idx: int) -> void:
+	var root := roots[idx]
+	var nodes := children[idx]
+	for i in ITERATIONS:
+		root.remove_child(nodes[i])

--- a/benchmarks/scene_nodes/get_node.gd
+++ b/benchmarks/scene_nodes/get_node.gd
@@ -1,0 +1,27 @@
+extends Benchmark
+
+const ITERATIONS = 50_000
+
+var root: Node
+var node_paths: Array[NodePath]
+
+# Benchmark get_node by calling it ITERATIONS times, once per node on tree.
+# All node paths are relative to the root node.
+# A random nesting tree is created in init.
+
+func _init() -> void:
+	root = Node.new()
+	var nodes: Array[Node] = [root]
+	for i in ITERATIONS:
+		var new_node := Node.new()
+		var random_parent := nodes[randi() % nodes.size()]
+		random_parent.add_child(new_node)
+		nodes.push_back(new_node)
+	
+	for node in nodes:
+		node_paths.push_back(root.get_path_to(node))
+
+
+func benchmark_get_node() -> void:
+	for path in node_paths:
+		root.get_node(path)

--- a/benchmarks/scene_nodes/move_children.gd
+++ b/benchmarks/scene_nodes/move_children.gd
@@ -1,0 +1,24 @@
+extends Benchmark
+
+# Moving children is much slower than other scene node operations,
+# so perform fewer iterations to ensure it completes in a reasonable amount of time.
+const ITERATIONS = 1_000
+
+var root: Node
+var children: Array[Node]
+
+# Benchmark move_child by moving to random positions ITERATIONS 
+# children ITERATIONS times. The tree is created in init.
+
+func _init() -> void:
+	root = Node.new()
+	for i in ITERATIONS:
+		root.add_child(Node.new())
+	children = root.get_children()
+
+
+func benchmark_move_children() -> void:
+	var size := children.size()
+	for node in children:
+		for i in ITERATIONS:
+			root.move_child(node, randi() % size)


### PR DESCRIPTION
Implements

🟪Algorithm🟪 [Adding 5000 children]: Unnamed: Adding 5000 random children nodes without name.
🟪Algorithm🟪 [Adding 5000 children]: Named: Adding 5000 random children nodes with the same name (let the conflict resolution happen).
🟪Algorithm🟪 Moving node children: Move 5000 children nodes between two random positions 5000 times.
🟪Algorithm🟪 [Delete children]: in order: Remove all 5000 children in order, first to last.
🟪Algorithm🟪 [Delete children]: in reverse order: Remove all 5000 children in order, last to first.
🟪Algorithm🟪 [Delete children]: in random order: Remove all 5000 children in random order.
🟪Algorithm🟪 Get node: Create a complex scene hierarchy of 1000 nodes with random nesting, Obtain paths of all nodes, test performance of get_node() for each one from root node.

from Scene nodes (base Node class) section in #36 benchmarks list.

P.S.: `get_node()` benchmark iterations were changed to 5000 as 1000 runs too fast.