### PR TITLE
Update project to the current stable version of Godot (4.2)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Godot Benchmarks"
 run/main_scene="res://main.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 config/icon="res://icon.png"
 
 [autoload]
@@ -28,6 +28,10 @@ gdscript/warnings/standalone_expression=0
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/stretch/mode="viewport"
+
+[dotnet]
+
+project/assembly_name="Godot Benchmarks"
 
 [gui]
 

--- a/project.godot
+++ b/project.godot
@@ -28,11 +28,6 @@ gdscript/warnings/standalone_expression=0
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/stretch/mode="viewport"
-
-[dotnet]
-
-project/assembly_name="Godot Benchmarks"
-
 [gui]
 
 theme/default_theme_scale=1.5

--- a/project.godot
+++ b/project.godot
@@ -28,6 +28,7 @@ gdscript/warnings/standalone_expression=0
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 window/stretch/mode="viewport"
+
 [gui]
 
 theme/default_theme_scale=1.5


### PR DESCRIPTION
This PR prevents users from seeing a warning about the project using an older version of Godot when loading.

I'm not sure if the inclusion of the `dotnet` config is welcome:

```tscn
[dotnet]

project/assembly_name="Godot Benchmarks"
```

I assume it got added due to me using a Mono build, but I see no downside to adding it to the project config file.
