### PR TITLE
fix convex hull benchmarks (multiple of 3)

### DIFF
--- a/benchmarks/math/convex_hull_3d.gd
+++ b/benchmarks/math/convex_hull_3d.gd
@@ -1,7 +1,7 @@
 extends Benchmark
 
 const NUM_ITERATIONS := 10
-const NUM_POINTS := 1002  # should be a multiple of three, triangles will be built with this
+const NUM_POINTS := 1002  # Should be a multiple of three, triangles will be built with this.
 const CLOUD_SIZE := 1.0
 const POSITION := Vector3(0.0, 0.0, 0.0)
 

--- a/benchmarks/math/convex_hull_3d.gd
+++ b/benchmarks/math/convex_hull_3d.gd
@@ -1,7 +1,7 @@
 extends Benchmark
 
-const NUM_ITERATIONS := 100
-const NUM_POINTS := 10_000
+const NUM_ITERATIONS := 10
+const NUM_POINTS := 1002  # should be a multiple of three, triangles will be built with this
 const CLOUD_SIZE := 1.0
 const POSITION := Vector3(0.0, 0.0, 0.0)
 


### PR DESCRIPTION
 The benchmark was bogus before. I missed this error:

        convex_hull_3d.gd:34 @ _bench_convex(): Ignoring surface 0, incorrect vertex count: 10000 (for PRIMITIVE_TRIANGLES).
        <C++ Error>    Condition "(len % 3) != 0" is true. Continuing.

Also tweaked the iteration count so it takes a reasonable time.

---

Fixes benchmarks introduced in #51.

Reference results on Mac M2:
![image](https://github.com/godotengine/godot-benchmarks/assets/726447/302e80a6-1b09-4363-ac71-47a3bd325e14)

