### PR TITLE
Add benchmark for viewport creation/activation

### DIFF
--- a/benchmarks/viewport/activation.gd
+++ b/benchmarks/viewport/activation.gd
@@ -1,8 +1,8 @@
 extends Benchmark
 
-# In godot 3.x a lot of the cost of viewport nodes comes during activation
-# IE: when you create it, add it to the tree, set the size and allocate the viewport texture...
-# The point when the underlying RENDER_TARGET is created is a huge weak point in some gpu drivers
+# In Godot, a lot of the cost of Viewport nodes comes during activation.
+# That is, when you create it, add it to the tree, set the size and allocate the viewport texture...
+# The point when the underlying render target is created is a huge weak point in some GPU drivers.
 const allocation = preload("./allocation.gd")
 
 

--- a/benchmarks/viewport/activation.gd
+++ b/benchmarks/viewport/activation.gd
@@ -1,0 +1,45 @@
+extends Benchmark
+
+# In godot 3.x a lot of the cost of viewport nodes comes during activation
+# IE: when you create it, add it to the tree, set the size and allocate the viewport texture...
+# The point when the underlying RENDER_TARGET is created is a huge weak point in some gpu drivers
+const allocation = preload("./allocation.gd")
+
+
+class TestScene extends Node2D:
+	var viewports: Array[SubViewport] = []
+	var viewports_added := false
+
+	func _init(count: int):
+		viewports = allocation.create_viewports(count)
+
+	func _ready():
+		var cl := CanvasLayer.new()
+		add_child(cl)
+		var i := 0
+		for vp in viewports:
+			var vpc = SubViewportContainer.new()
+			vpc.add_child(vp)
+			vpc.size = Vector2.ONE * allocation.VIEWPORT_SIZE
+			cl.add_child(vpc)
+			vpc.position = Vector2.ONE * ((i * 10) % 1024)
+			i += 1
+
+
+func activate_viewports(count: int):
+	var node = TestScene.new(count)
+	Manager.get_tree().root.add_child(node)
+	await Manager.get_tree().process_frame
+	node.free()
+
+
+func benchmark_activate_64_viewports():
+	await activate_viewports(64)
+
+
+func benchmark_activate_256_viewports():
+	await activate_viewports(256)
+
+
+func benchmark_activate_1024_viewports():
+	await activate_viewports(1024)

--- a/benchmarks/viewport/allocation.gd
+++ b/benchmarks/viewport/allocation.gd
@@ -1,0 +1,32 @@
+extends Benchmark
+
+const VIEWPORT_SIZE = 512
+
+func _init() -> void:
+	pass
+
+
+static func create_viewports(count: int) -> Array[SubViewport]:
+	var viewports : Array[SubViewport] = []
+	for i in range(count):
+		var vp := SubViewport.new()
+		vp.size = Vector2.ONE * VIEWPORT_SIZE
+		viewports.append(vp)
+	return viewports
+
+
+static func free_items(items: Array):
+	for item in items:
+		item.free()
+
+
+func benchmark_create_64_viewports():
+	free_items(create_viewports(64))
+
+
+func benchmark_create_256_viewports():
+	free_items(create_viewports(256))
+
+
+func benchmark_create_1024_viewports():
+	free_items(create_viewports(1024))

--- a/manager.gd
+++ b/manager.gd
@@ -148,7 +148,8 @@ func run_test(test_id: TestID) -> void:
 
 	# Call and time the function to be tested
 	var begin_time := Time.get_ticks_usec()
-	var bench_node = bench_script.call(languages[test_id.language]["test_prefix"] + test_id.name)
+	# redundant awaits don't cause a performance variation afaict
+	var bench_node = await bench_script.call(languages[test_id.language]["test_prefix"] + test_id.name)
 	results.time = (Time.get_ticks_usec() - begin_time) * 0.001
 
 	# Continue benchmarking if the function call has returned a node

--- a/manager.gd
+++ b/manager.gd
@@ -148,7 +148,7 @@ func run_test(test_id: TestID) -> void:
 
 	# Call and time the function to be tested
 	var begin_time := Time.get_ticks_usec()
-	# redundant awaits don't cause a performance variation afaict
+	# Redundant awaits don't seem to cause a performance variation.
 	var bench_node = await bench_script.call(languages[test_id.language]["test_prefix"] + test_id.name)
 	results.time = (Time.get_ticks_usec() - begin_time) * 0.001
 


### PR DESCRIPTION
This benchmark shows a large variability across gpu drivers and devices with regard to creating and 'activating' subviewports.

'Activating' a subviewport involves creating a SubViewport node, adding it to the scene tree and rendering a frame.

These benchmarks test three levels of strain on the system by creating 'a few' (64) 'many' (256) and 'too many' (1024) subviewports in different benchmarks.

(after running these benchmarks I reduced the viewport size to 512x512 as I noticed the memory usage for 1024x1024 x 1024 subviewports was _rediculous_)
```
Godot v4.3.dev5 - Windows 10.0.22631 - Intel(R) Core(TM) i7-8650U CPU @ 1.90GHz (8 Threads)
1: Vulkan 1.3.215 - Forward+ - Using Device #0: Intel - Intel(R) UHD Graphics 620
2: OpenGL API 3.3.0 - Build 31.0.101.2115 - Compatibility - Using Device: Intel - Intel(R) UHD Graphics 620
3: OpenGL API OpenGL ES 3.0.0 (ANGLE 2.1.21969 git hash: 9528449a8930) - Compatibility - Using Device: Google Inc. (Intel) - ANGLE (Intel, Intel(R) UHD Graphics 620 (0x00005917) Direct3D11 vs_5_0 ps_5_0, D3D11-31.0.101.2115)
4: D3D12 12_0 - Forward+ - Using Device #0: Intel - Intel(R) UHD Graphics 620

Godot v4.3.dev5 - Ubuntu 22.04.4 LTS 22.04 - X11 - 12th Gen Intel(R) Core(TM) i7-12700H (14 Threads)
5: Vulkan 1.3.255 - Forward+ - Using Device #0: Intel - Intel(R) Graphics (ADL GT2)
6: OpenGL API 4.6 (Core Profile) Mesa 23.2.1-1ubuntu3.1~22.04.2 - Compatibility - Using Device: Intel - Mesa Intel(R) Graphics (ADL GT2)
7: OpenGL API OpenGL ES 3.2 Mesa 23.2.1-1ubuntu3.1~22.04.2 - Compatibility - Using Device: Intel - Mesa Intel(R) Graphics (ADL GT2)

Godot v4.3.dev5 - Ubuntu 22.04.4 LTS 22.04 - X11 - 12th Gen Intel(R) Core(TM) i7-12700H (14 Threads)
8: Vulkan 1.3.242 - Forward+ - Using Device #2: NVIDIA - NVIDIA GeForce RTX 3050 Laptop GPU
9: OpenGL API 3.3.0 NVIDIA 535.161.07 - Compatibility - Using Device: NVIDIA - NVIDIA GeForce RTX 3050 Laptop GPU
10 OpenGL API OpenGL ES 3.2 NVIDIA 535.161.07 - Compatibility - Using Device: NVIDIA - NVIDIA GeForce RTX 3050 Laptop GPU
```
```
Running benchmark 1 of 6: viewport/activation/activate_a_few_viewports
1  Result: {"time":127.7}
2  Result: {"time":303.4}
3  Result: {"time":532.1}
5  Result: {"time":54.19}
5  Result: {"time":10.4}
6  Result: {"time":123.7}
7  Result: {"time":119}
8  Result: {"time":10.84}
9  Result: {"time":104.8}
10 Result: {"time":103.3}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
1  Result: {"time":479.4}
2  Result: {"time":2167}
3  Result: {"time":1771}
5  Result: {"time":178}
5  Result: {"time":35.44}
6  Result: {"time":281.3}
7  Result: {"time":282.5}
8  Result: {"time":36.07}
9  Result: {"time":116.8}
10 Result: {"time":121.2}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
1  Result: {"time":6963}
2  Result: {"time":77330}
3  Result: {"time":12090}
5  Result: {"time":721.7}
5  Result: {"time":1522}
6  Result: {"time":1175}
7  Result: {"time":1209}
8  Result: {"time":1551}
9  Result: {"time":6418}
10 Result: {"time":6054}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
1  Result: {"time":7.499}
2  Result: {"time":442.4}
3  Result: {"time":156.1}
5  Result: {"time":3.019}
5  Result: {"time":2.741}
6  Result: {"time":4.544}
7  Result: {"time":3.246}
8  Result: {"time":2.882}
9  Result: {"time":24.26}
10 Result: {"time":23.44}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
1  Result: {"time":63.82}
2  Result: {"time":2413}
3  Result: {"time":676.2}
5  Result: {"time":7.024}
5  Result: {"time":7.152}
6  Result: {"time":10.74}
7  Result: {"time":22.4}
8  Result: {"time":7.473}
9  Result: {"time":91.09}
10 Result: {"time":91.41}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
1  Result: {"time":1810}
2  Result: {"time":35870}
3  Result: {"time":3450}
5  Result: {"time":58.49}
5  Result: {"time":1516}
6  Result: {"time":33.37}
7  Result: {"time":36.47}
8  Result: {"time":1555}
9  Result: {"time":6606}
10 Result: {"time":6209}

2

Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":303.4}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":2167}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":77330}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":442.4}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":2413}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":35870}


3
Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":532.1}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":1771}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":12090}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":156.1}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":676.2}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":3450}

4
no output, silent crash?

5
Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":54.19}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":178}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":721.7}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":3.019}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":7.024}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":58.49}
===
Running benchmark 1 of 6: viewport/activation/activate_a_few_viewports
Result: {"time":10.4}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":35.44}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":1522}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":2.741}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":7.152}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":1516}
===
Running benchmark 1 of 6: viewport/activation/activate_a_few_viewports
Result: {"time":10.35}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":36.08}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":1555}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":2.43}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":7.447}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":1516}


6
Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":123.7}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":281.3}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":1175}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":4.544}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":10.74}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":33.37}

7
Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":119}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":282.5}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":1209}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":3.246}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":22.4}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":36.47}

8
Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":10.84}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":36.07}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":1551}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":2.882}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":7.473}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":1555}

9
Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":104.8}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":116.8}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":6418}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":24.26}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":91.09}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":6606}

10
Running benchmark 1 of 6: viewport/activation/activate_a_fiew_viewports
Result: {"time":103.3}

Running benchmark 2 of 6: viewport/activation/activate_many_viewports
Result: {"time":121.2}

Running benchmark 3 of 6: viewport/activation/activate_too_many_viewports
Result: {"time":6054}

Running benchmark 4 of 6: viewport/allocation/create_a_few_viewports
Result: {"time":23.44}

Running benchmark 5 of 6: viewport/allocation/create_many_viewports
Result: {"time":91.41}

Running benchmark 6 of 6: viewport/allocation/create_too_many_viewports
Result: {"time":6209}
```