### PR TITLE
Add CanvasItem drawing benchmarks

### DIFF
--- a/benchmarks/rendering/canvas_item.gd
+++ b/benchmarks/rendering/canvas_item.gd
@@ -1,0 +1,68 @@
+extends Benchmark
+
+const ICON := preload("res://icon.png")
+
+
+func _init() -> void:
+	test_render_cpu = true
+	test_render_gpu = true
+
+
+class TestScene:
+	extends Node2D
+	var shape_amount := 0
+	var window_size: Vector2i
+	var draw_every_frame := false
+
+	func _init(_shape_amount: int, _draw_every_frame: bool) -> void:
+		shape_amount = _shape_amount
+		draw_every_frame = _draw_every_frame
+
+	func _ready() -> void:
+		window_size = get_window().size
+		set_process(draw_every_frame)
+
+	func _process(_delta: float) -> void:
+		queue_redraw()
+
+	func _draw() -> void:
+		for i in shape_amount:
+			var x := (i * 20) % window_size.x
+			var y := (i * 200) / window_size.x
+			var center := Vector2(x, y)
+			var remainder := i % 5
+			match remainder:
+				0:
+					draw_circle(center, 1.0, Color.GREEN)
+				1:
+					draw_rect(Rect2(center - Vector2.ONE, Vector2.ONE * 2.0), Color.GREEN)
+				2:
+					draw_line(center - Vector2.ONE, center + Vector2.ONE, Color.GREEN)
+				3:
+					draw_dashed_line(center - Vector2.ONE, center + Vector2.ONE, Color.GREEN)
+				4:
+					draw_texture(ICON, center)
+
+
+func benchmark_draw_5000_shapes_once() -> TestScene:
+	return TestScene.new(5000, false)
+
+
+func benchmark_draw_5000_shapes_every_frame() -> TestScene:
+	return TestScene.new(5000, true)
+
+
+func benchmark_draw_10_000_shapes_once() -> TestScene:
+	return TestScene.new(10_000, false)
+
+
+func benchmark_draw_10_000_shapes_every_frame() -> TestScene:
+	return TestScene.new(10_000, true)
+
+
+func benchmark_draw_20_000_shapes_once() -> TestScene:
+	return TestScene.new(20_000, false)
+
+
+func benchmark_draw_20_000_shapes_every_frame() -> TestScene:
+	return TestScene.new(20_000, true)


### PR DESCRIPTION
Adds the following benchmarks from #36:
- 🟥CPU🟥 [CanvasItem]: Rendering: Draw different shapes (images, circles, etc) using the CanvasItem 2D drawing API. Draw 5000 elements. Measure performance.
- 🟥CPU🟥 [CanvasItem]: Re-Rendering: Same as above, but every frame call queue_update() so it redraws. Measure performance.

I am quite puzzled as to why drawing the elements once sometimes results in more CPU & GPU time, than re-rendering them every frame. I added benchmarks for 10000 and 20000 elements in case 5000 is too low and it's being affected by an error margin, but I still get weird results for these benchmarks as well. Not sure if I'm doing something wrong, the logic seems fine to me, but let me know if I should keep or remove the benchmarks for 10000 & 20000 elements.

<details>
<summary>Results on my PC</summary>

{
	"benchmarks": [
		{
			"category": "Rendering > Canvas Item",
			"name": "Draw 10 000 Shapes Every Frame",
			"results": {
				"render_cpu": 2.542,
				"render_gpu": 4.311,
				"time": 0.029
			}
		},
		{
			"category": "Rendering > Canvas Item",
			"name": "Draw 10 000 Shapes Once",
			"results": {
				"render_cpu": 2.563,
				"render_gpu": 4.435,
				"time": 0.035
			}
		},
		{
			"category": "Rendering > Canvas Item",
			"name": "Draw 20 000 Shapes Every Frame",
			"results": {
				"render_cpu": 5.243,
				"render_gpu": 8.6,
				"time": 0.023
			}
		},
		{
			"category": "Rendering > Canvas Item",
			"name": "Draw 20 000 Shapes Once",
			"results": {
				"render_cpu": 5.02,
				"render_gpu": 8.739,
				"time": 0.049
			}
		},
		{
			"category": "Rendering > Canvas Item",
			"name": "Draw 5000 Shapes Every Frame",
			"results": {
				"render_cpu": 1.216,
				"render_gpu": 2.162,
				"time": 0.041
			}
		},
		{
			"category": "Rendering > Canvas Item",
			"name": "Draw 5000 Shapes Once",
			"results": {
				"render_cpu": 1.336,
				"render_gpu": 2.21,
				"time": 0.1
			}
		}
	],
	"engine": {
		"version": "v4.3.beta1.official",
		"version_hash": "a4f2ea91a1bd18f70a43ff4c1377db49b56bc3f0"
	},
	"system": {
		"cpu_architecture": "x86_64",
		"cpu_count": 12,
		"cpu_name": "AMD Ryzen 5 1600 Six-Core Processor",
		"os": "Linux"
	}
}

</details>