### PR TITLE
Allow the benchmark time limit to be changed by individual benchmarks

### DIFF
--- a/benchmark.gd
+++ b/benchmark.gd
@@ -1,8 +1,9 @@
 class_name Benchmark
 
+
+## Set default benchmark time limit to 5 seconds (5 million microseconds).
+var benchmark_time := 5e6
 var test_render_cpu : = false
 var test_render_gpu : = false
 var test_idle : = false
 var test_physics : = false
-
-

--- a/benchmarks/physics/area_2d.gd
+++ b/benchmarks/physics/area_2d.gd
@@ -68,6 +68,7 @@ class TestScene:
 
 
 func _init() -> void:
+	benchmark_time = 10e6
 	test_physics = true
 	test_idle = true
 

--- a/benchmarks/physics/character_body_2d.gd
+++ b/benchmarks/physics/character_body_2d.gd
@@ -58,6 +58,7 @@ class TestScene:
 
 
 func _init() -> void:
+	benchmark_time = 10e6
 	test_physics = true
 	test_idle = true
 

--- a/benchmarks/physics/rigid_body_2d.gd
+++ b/benchmarks/physics/rigid_body_2d.gd
@@ -11,109 +11,110 @@ var square_mesh := QuadMesh.new()
 var circle_mesh := SphereMesh.new()
 
 func _init() -> void:
-    square_mesh.size = Vector2(20.0, 20.0);
-    circle_mesh.radius = 10.0;
-    circle_mesh.height = 20.0;
-    test_physics = true
-    test_idle = true
+	square_mesh.size = Vector2(20.0, 20.0);
+	circle_mesh.radius = 10.0;
+	circle_mesh.height = 20.0;
+	benchmark_time = 10e6
+	test_physics = true
+	test_idle = true
 
 
 func setup_scene(create_body_func: Callable, unique_shape: bool, ccd_mode: RigidBody2D.CCDMode, boundary: bool, num_shapes: int) -> Node2D:
-    var scene_root := Node2D.new()
+	var scene_root := Node2D.new()
 
-    if VISUALIZE:
-        var camera := Camera2D.new()
-        camera.position = Vector2(0.0, -100.0)
-        camera.zoom = Vector2(0.5, 0.5)
-        scene_root.add_child(camera)
+	if VISUALIZE:
+		var camera := Camera2D.new()
+		camera.position = Vector2(0.0, -100.0)
+		camera.zoom = Vector2(0.5, 0.5)
+		scene_root.add_child(camera)
 
-    if boundary:
-        var pit := StaticBody2D.new();
-        pit.add_child(create_wall(Vector2(SPREAD_H, 0.0), -0.1))
-        pit.add_child(create_wall(Vector2(-SPREAD_H, 0.0), 0.1))
-        scene_root.add_child(pit);
+	if boundary:
+		var pit := StaticBody2D.new();
+		pit.add_child(create_wall(Vector2(SPREAD_H, 0.0), -0.1))
+		pit.add_child(create_wall(Vector2(-SPREAD_H, 0.0), 0.1))
+		scene_root.add_child(pit);
 
-    for _i in num_shapes:
-        var body: RigidBody2D = create_body_func.call(unique_shape, ccd_mode)
-        body.position = Vector2(randf_range(-SPREAD_H, SPREAD_H), randf_range(0.0, -SPREAD_V))
-        scene_root.add_child(body)
+	for _i in num_shapes:
+		var body: RigidBody2D = create_body_func.call(unique_shape, ccd_mode)
+		body.position = Vector2(randf_range(-SPREAD_H, SPREAD_H), randf_range(0.0, -SPREAD_V))
+		scene_root.add_child(body)
 
-    return scene_root
+	return scene_root
 
 
 func create_wall(position: Vector2, rotation: float) -> CollisionShape2D:
-    var wall := CollisionShape2D.new()
-    wall.shape = boundary_shape
-    wall.position = position
-    wall.rotation = rotation
-    return wall
+	var wall := CollisionShape2D.new()
+	wall.shape = boundary_shape
+	wall.position = position
+	wall.rotation = rotation
+	return wall
 
 
 func create_random_shape(unique_shape: bool, ccd_mode: RigidBody2D.CCDMode) -> RigidBody2D:
-    match randi_range(0, 1):
-        0: return create_square(unique_shape, ccd_mode)
-        _: return create_circle(unique_shape, ccd_mode)
+	match randi_range(0, 1):
+		0: return create_square(unique_shape, ccd_mode)
+		_: return create_circle(unique_shape, ccd_mode)
 
 
 func create_square(unique_shape: bool, ccd_mode: RigidBody2D.CCDMode) -> RigidBody2D:
-    var rigid_body := RigidBody2D.new()
-    var collision_shape := CollisionShape2D.new()
-    rigid_body.continuous_cd = ccd_mode
+	var rigid_body := RigidBody2D.new()
+	var collision_shape := CollisionShape2D.new()
+	rigid_body.continuous_cd = ccd_mode
 
-    if VISUALIZE:
-        var mesh_instance := MeshInstance2D.new()
-        mesh_instance.mesh = square_mesh
-        rigid_body.add_child(mesh_instance)
+	if VISUALIZE:
+		var mesh_instance := MeshInstance2D.new()
+		mesh_instance.mesh = square_mesh
+		rigid_body.add_child(mesh_instance)
 
-    if unique_shape:
-        collision_shape.shape = RectangleShape2D.new()
-    else:
-        # Reuse existing shape.
-        collision_shape.shape = square_shape
-    rigid_body.add_child(collision_shape)
+	if unique_shape:
+		collision_shape.shape = RectangleShape2D.new()
+	else:
+		# Reuse existing shape.
+		collision_shape.shape = square_shape
+	rigid_body.add_child(collision_shape)
 
-    return rigid_body
+	return rigid_body
 
 
 func create_circle(unique_shape: bool, ccd_mode: RigidBody2D.CCDMode) -> RigidBody2D:
-    var rigid_body := RigidBody2D.new()
-    var collision_shape := CollisionShape2D.new()
-    rigid_body.continuous_cd = ccd_mode
+	var rigid_body := RigidBody2D.new()
+	var collision_shape := CollisionShape2D.new()
+	rigid_body.continuous_cd = ccd_mode
 
-    if VISUALIZE:
-        var mesh_instance := MeshInstance2D.new()
-        mesh_instance.mesh = circle_mesh
-        rigid_body.add_child(mesh_instance)
+	if VISUALIZE:
+		var mesh_instance := MeshInstance2D.new()
+		mesh_instance.mesh = circle_mesh
+		rigid_body.add_child(mesh_instance)
 
-    if unique_shape:
-        collision_shape.shape = CircleShape2D.new()
-    else:
-        # Reuse existing shape.
-        collision_shape.shape = circle_shape
-    rigid_body.add_child(collision_shape)
+	if unique_shape:
+		collision_shape.shape = CircleShape2D.new()
+	else:
+		# Reuse existing shape.
+		collision_shape.shape = circle_shape
+	rigid_body.add_child(collision_shape)
 
-    return rigid_body
+	return rigid_body
 
 
 func benchmark_2000_rigid_body_2d_squares() -> Node2D:
-    return setup_scene(create_square, false, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
+	return setup_scene(create_square, false, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
 
 
 func benchmark_2000_rigid_body_2d_circles() -> Node2D:
-    return setup_scene(create_circle, false, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
+	return setup_scene(create_circle, false, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
 
 
 func benchmark_2000_rigid_body_2d_mixed() -> Node2D:
-    return setup_scene(create_random_shape, false, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
+	return setup_scene(create_random_shape, false, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
 
 
 func benchmark_2000_rigid_body_2d_unique() -> Node2D:
-    return setup_scene(create_random_shape, true, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
+	return setup_scene(create_random_shape, true, RigidBody2D.CCD_MODE_DISABLED, true, 2000)
 
 
 func benchmark_2000_rigid_body_2d_continuous() -> Node2D:
-    return setup_scene(create_random_shape, false, RigidBody2D.CCD_MODE_CAST_SHAPE, true, 2000)
+	return setup_scene(create_random_shape, false, RigidBody2D.CCD_MODE_CAST_SHAPE, true, 2000)
 
 
 func benchmark_2000_rigid_body_2d_unbound() -> Node2D:
-    return setup_scene(create_random_shape, false, RigidBody2D.CCD_MODE_DISABLED, false, 2000)
+	return setup_scene(create_random_shape, false, RigidBody2D.CCD_MODE_DISABLED, false, 2000)

--- a/benchmarks/physics/rigid_body_3d.gd
+++ b/benchmarks/physics/rigid_body_3d.gd
@@ -11,6 +11,7 @@ var box_mesh := BoxMesh.new()
 var sphere_mesh := SphereMesh.new()
 
 func _init() -> void:
+	benchmark_time = 10e6
 	test_physics = true
 	test_idle = true
 

--- a/manager.gd
+++ b/manager.gd
@@ -168,7 +168,6 @@ func run_test(test_id: TestID) -> void:
 		var time_limit = bench_script.get("benchmark_time")
 		begin_time = Time.get_ticks_usec()
 
-		# Time limit of 5 seconds (5 million microseconds).
 		while (Time.get_ticks_usec() - begin_time) < time_limit:
 			await get_tree().process_frame
 

--- a/manager.gd
+++ b/manager.gd
@@ -165,7 +165,7 @@ func run_test(test_id: TestID) -> void:
 		for i in 3:
 			await get_tree().process_frame
 
-		var time_limit = bench_script.get("benchmark_time")
+		var time_limit: int = bench_script.get("benchmark_time")
 		begin_time = Time.get_ticks_usec()
 
 		while (Time.get_ticks_usec() - begin_time) < time_limit:

--- a/manager.gd
+++ b/manager.gd
@@ -165,10 +165,11 @@ func run_test(test_id: TestID) -> void:
 		for i in 3:
 			await get_tree().process_frame
 
+		var time_limit = bench_script.get("benchmark_time")
 		begin_time = Time.get_ticks_usec()
 
 		# Time limit of 5 seconds (5 million microseconds).
-		while (Time.get_ticks_usec() - begin_time) < 5e6:
+		while (Time.get_ticks_usec() - begin_time) < time_limit:
 			await get_tree().process_frame
 
 			results.render_cpu += RenderingServer.viewport_get_measured_render_time_cpu(get_tree().root.get_viewport_rid())  + RenderingServer.get_frame_setup_time_cpu()


### PR DESCRIPTION
This allows individual benchmarks to change the benchmark time limit, which is requested for certain benchmarks, such as the physics ones (#72). Benchmarks that don't return a node are still unaffected by the limit, although I could change this if desired. This PR also sets the timer of all physics benchmarks to 10 seconds. `rigid_body_2d.gd` doesn't actually have any changes besides this, the rest of the changes were formatting made by the Godot editor itself.