### PR TITLE
Add cull and lightmap probe influence benchmarks

### DIFF
--- a/benchmarks/rendering/culling.gd
+++ b/benchmarks/rendering/culling.gd
@@ -20,6 +20,7 @@ class TestScene:
 	var cam := Camera3D.new()
 	var dynamic_instances
 	var dynamic_instances_xforms
+	var dynamic_instances_rotate := false
 	var time_accum := 0.0
 	var unshaded := false
 	var use_shadows := false
@@ -140,7 +141,10 @@ class TestScene:
 		for i in dynamic_instances.size():
 			var xf: Transform3D = dynamic_instances_xforms[i]
 			var angle = i * PI * 2.0 / dynamic_instances.size()
-			xf.origin += Vector3(sin(angle), cos(angle), 0.0) * sin(time_accum) * 2.0
+			if dynamic_instances_rotate:
+				xf = xf.rotated_local(Vector3.RIGHT, angle * sin(time_accum) * 2.0)
+			else:
+				xf.origin += Vector3(sin(angle), cos(angle), 0.0) * sin(time_accum) * 2.0
 			RenderingServer.instance_set_transform(dynamic_instances[i], xf)
 
 
@@ -164,6 +168,15 @@ func benchmark_directional_light_cull():
 
 func benchmark_dynamic_cull():
 	var rv := TestScene.new()
+	rv.fill_with_objects = true
+	rv.dynamic_instances = rv.objects
+	rv.dynamic_instances_xforms = rv.object_xforms
+	return rv
+
+
+func benchmark_dynamic_rotate_cull():
+	var rv := TestScene.new()
+	rv.dynamic_instances_rotate = true
 	rv.fill_with_objects = true
 	rv.dynamic_instances = rv.objects
 	rv.dynamic_instances_xforms = rv.object_xforms

--- a/benchmarks/rendering/culling.gd
+++ b/benchmarks/rendering/culling.gd
@@ -1,7 +1,7 @@
 extends Benchmark
 
-const NUMBER_OF_OBJECTS = 10_000
-const NUMBER_OF_OMNI_LIGHTS = 100
+const NUMBER_OF_OBJECTS := 10_000
+const NUMBER_OF_OMNI_LIGHTS := 100
 
 
 func _init() -> void:
@@ -11,15 +11,15 @@ func _init() -> void:
 
 class TestScene:
 	extends Node3D
-	var objects := []
-	var object_xforms := []
-	var lights := []
-	var light_instances := []
-	var light_instance_xforms := []
-	var meshes := []
+	var objects: Array[RID] = []
+	var object_xforms: Array[Transform3D] = []
+	var lights: Array[RID] = []
+	var light_instances: Array[RID] = []
+	var light_instance_xforms: Array[Transform3D] = []
+	var meshes: Array[PrimitiveMesh] = []
 	var cam := Camera3D.new()
-	var dynamic_instances
-	var dynamic_instances_xforms
+	var dynamic_instances: Array[RID]
+	var dynamic_instances_xforms: Array[Transform3D]
 	var dynamic_instances_rotate := false
 	var time_accum := 0.0
 	var unshaded := false
@@ -27,12 +27,12 @@ class TestScene:
 	var fill_with_objects := false
 	var fill_with_omni_lights := false
 
-	func _init():
+	func _init() -> void:
 		cam.far = 200.0
 		cam.transform.origin.z = 0.873609
 		add_child(cam)
 
-	func _ready():
+	func _ready() -> void:
 		cam.make_current()
 		if fill_with_objects:
 			do_fill_with_objects()
@@ -139,8 +139,8 @@ class TestScene:
 		time_accum += delta * 4.0
 
 		for i in dynamic_instances.size():
-			var xf: Transform3D = dynamic_instances_xforms[i]
-			var angle = i * PI * 2.0 / dynamic_instances.size()
+			var xf := dynamic_instances_xforms[i]
+			var angle := i * PI * 2.0 / dynamic_instances.size()
 			if dynamic_instances_rotate:
 				xf = xf.rotated_local(Vector3.RIGHT, angle * sin(time_accum) * 2.0)
 			else:
@@ -148,14 +148,14 @@ class TestScene:
 			RenderingServer.instance_set_transform(dynamic_instances[i], xf)
 
 
-func benchmark_basic_cull():
+func benchmark_basic_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	rv.unshaded = true
 	return rv
 
 
-func benchmark_directional_light_cull():
+func benchmark_directional_light_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	var light := DirectionalLight3D.new()
@@ -166,7 +166,7 @@ func benchmark_directional_light_cull():
 	return rv
 
 
-func benchmark_dynamic_cull():
+func benchmark_dynamic_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	rv.dynamic_instances = rv.objects
@@ -174,7 +174,7 @@ func benchmark_dynamic_cull():
 	return rv
 
 
-func benchmark_dynamic_rotate_cull():
+func benchmark_dynamic_rotate_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.dynamic_instances_rotate = true
 	rv.fill_with_objects = true
@@ -183,7 +183,7 @@ func benchmark_dynamic_rotate_cull():
 	return rv
 
 
-func benchmark_dynamic_light_cull():
+func benchmark_dynamic_light_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	rv.fill_with_omni_lights = true
@@ -192,7 +192,7 @@ func benchmark_dynamic_light_cull():
 	return rv
 
 
-func benchmark_dynamic_light_cull_with_shadows():
+func benchmark_dynamic_light_cull_with_shadows() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	rv.fill_with_omni_lights = true
@@ -202,7 +202,7 @@ func benchmark_dynamic_light_cull_with_shadows():
 	return rv
 
 
-func benchmark_static_light_cull():
+func benchmark_static_light_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	rv.fill_with_omni_lights = true

--- a/benchmarks/rendering/culling.gd
+++ b/benchmarks/rendering/culling.gd
@@ -155,17 +155,6 @@ func benchmark_basic_cull() -> TestScene:
 	return rv
 
 
-func benchmark_directional_light_cull() -> TestScene:
-	var rv := TestScene.new()
-	rv.fill_with_objects = true
-	var light := DirectionalLight3D.new()
-	light.shadow_enabled = true
-	light.rotation = Vector3(-0.6, 0.3, -0.3)
-	light.position.x = 2
-	rv.add_child(light)
-	return rv
-
-
 func benchmark_dynamic_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
@@ -183,7 +172,25 @@ func benchmark_dynamic_rotate_cull() -> TestScene:
 	return rv
 
 
-func benchmark_dynamic_light_cull() -> TestScene:
+func benchmark_directional_light_cull() -> TestScene:
+	var rv := TestScene.new()
+	rv.fill_with_objects = true
+	var light := DirectionalLight3D.new()
+	light.shadow_enabled = true
+	light.rotation = Vector3(-0.6, 0.3, -0.3)
+	light.position.x = 2
+	rv.add_child(light)
+	return rv
+
+
+func benchmark_static_omni_light_cull() -> TestScene:
+	var rv := TestScene.new()
+	rv.fill_with_objects = true
+	rv.fill_with_omni_lights = true
+	return rv
+
+
+func benchmark_dynamic_omni_light_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	rv.fill_with_omni_lights = true
@@ -192,18 +199,11 @@ func benchmark_dynamic_light_cull() -> TestScene:
 	return rv
 
 
-func benchmark_dynamic_light_cull_with_shadows() -> TestScene:
+func benchmark_dynamic_omni_light_cull_with_shadows() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true
 	rv.fill_with_omni_lights = true
 	rv.use_shadows = true
 	rv.dynamic_instances = rv.light_instances
 	rv.dynamic_instances_xforms = rv.light_instance_xforms
-	return rv
-
-
-func benchmark_static_light_cull() -> TestScene:
-	var rv := TestScene.new()
-	rv.fill_with_objects = true
-	rv.fill_with_omni_lights = true
 	return rv

--- a/benchmarks/rendering/culling.gd
+++ b/benchmarks/rendering/culling.gd
@@ -190,6 +190,14 @@ func benchmark_static_omni_light_cull() -> TestScene:
 	return rv
 
 
+func benchmark_static_omni_light_cull_with_shadows() -> TestScene:
+	var rv := TestScene.new()
+	rv.fill_with_objects = true
+	rv.fill_with_omni_lights = true
+	rv.use_shadows = true
+	return rv
+
+
 func benchmark_dynamic_omni_light_cull() -> TestScene:
 	var rv := TestScene.new()
 	rv.fill_with_objects = true

--- a/benchmarks/rendering/lightmap_probe_influence.gd
+++ b/benchmarks/rendering/lightmap_probe_influence.gd
@@ -26,12 +26,6 @@ class TestScene:
 		var lightmap := LightmapGI.new()
 		lightmap.light_data = load("res://supplemental/sponza.lmbake")
 		$Sponza.add_child(lightmap)
-		var half_probes := NUMBER_OF_PROBES / 2
-		for i in NUMBER_OF_PROBES:
-			var probe := LightmapProbe.new()
-			probe.position.y = 1
-			probe.position.z = i - half_probes
-			$Sponza.add_child(probe)
 
 		var meshes: Array[PrimitiveMesh] = [
 			BoxMesh.new(),
@@ -43,6 +37,7 @@ class TestScene:
 		var half_objects := NUMBER_OF_OBJECTS / 2
 		for i in NUMBER_OF_OBJECTS:
 			var ins := MeshInstance3D.new()
+			ins.gi_mode = GeometryInstance3D.GI_MODE_DYNAMIC
 			ins.mesh = meshes[i % meshes.size()]
 			ins.position.y = 1
 			ins.position.z = i - half_objects

--- a/benchmarks/rendering/lightmap_probe_influence.gd
+++ b/benchmarks/rendering/lightmap_probe_influence.gd
@@ -1,6 +1,7 @@
 extends Benchmark
 
 const NUMBER_OF_OBJECTS := 1000
+const NUMBER_OF_PROBES := 500
 
 
 func _init() -> void:
@@ -25,13 +26,12 @@ class TestScene:
 		var lightmap := LightmapGI.new()
 		lightmap.light_data = load("res://supplemental/sponza.lmbake")
 		$Sponza.add_child(lightmap)
-		# Create 512 probes
-		for x in 8:
-			for y in 8:
-				for z in range(-2, 6):
-					var probe := LightmapProbe.new()
-					probe.position = Vector3(x, y, z)
-					$Sponza.add_child(probe)
+		var half_probes := NUMBER_OF_PROBES / 2
+		for i in NUMBER_OF_PROBES:
+			var probe := LightmapProbe.new()
+			probe.position.y = 1
+			probe.position.z = i - half_probes
+			$Sponza.add_child(probe)
 
 		var meshes: Array[PrimitiveMesh] = [
 			BoxMesh.new(),

--- a/benchmarks/rendering/lightmap_probe_influence.gd
+++ b/benchmarks/rendering/lightmap_probe_influence.gd
@@ -1,0 +1,62 @@
+extends Benchmark
+
+const NUMBER_OF_OBJECTS := 1000
+
+
+func _init() -> void:
+	test_render_cpu = true
+	test_render_gpu = true
+
+
+class TestScene:
+	extends Node3D
+
+	var sponza_scene := preload("res://supplemental/sponza.tscn")
+	var sponza: Node
+	var time_accum := 0.0
+	var objects: Array[MeshInstance3D]
+
+	func _init() -> void:
+		sponza = sponza_scene.instantiate()
+		add_child(sponza)
+
+	func _ready() -> void:
+		$"Sponza/OmniLights".visible = false
+		var lightmap := LightmapGI.new()
+		lightmap.light_data = load("res://supplemental/sponza.lmbake")
+		$Sponza.add_child(lightmap)
+		# Create 512 probes
+		for x in 8:
+			for y in 8:
+				for z in range(-2, 6):
+					var probe := LightmapProbe.new()
+					probe.position = Vector3(x, y, z)
+					$Sponza.add_child(probe)
+
+		var meshes: Array[PrimitiveMesh] = [
+			BoxMesh.new(),
+			SphereMesh.new(),
+			CapsuleMesh.new(),
+			CylinderMesh.new(),
+			PrismMesh.new(),
+		]
+		var half_objects := NUMBER_OF_OBJECTS / 2
+		for i in NUMBER_OF_OBJECTS:
+			var ins := MeshInstance3D.new()
+			ins.mesh = meshes[i % meshes.size()]
+			ins.position.y = 1
+			ins.position.z = i - half_objects
+			$Sponza.add_child(ins)
+			objects.append(ins)
+
+	func _process(delta: float) -> void:
+		time_accum += delta * 2.0
+		for i in objects.size():
+			objects[i].position.x = sin(time_accum) * 6.0
+
+	func _exit_tree() -> void:
+		RenderingServer.free_rid(sponza)
+
+
+func benchmark_lightmap_probe_influence() -> TestScene:
+	return TestScene.new()


### PR DESCRIPTION
Adds the following benchmarks from #36:
- 🟥CPU🟥 [Cull]: Rotating: Cull 10k rotating objects
- 🟥CPU🟥 [Cull Omni Shadows]: Static: Cull 10k objects, 200 omni lights with shadows, static
- 🟥CPU🟥 [Cull Spot Shadows]: Static: Cull 10k objects, 200 omni lights with shadows, static
- 🟥CPU🟥 [Cull Spot Shadows]: Dynamic: Cull 10k objects, 200 omni lights with shadows, lights move around.
- 🟥CPU🟥 Lightmap probe influence : Simple scene baked with lightmaps (and using tons of probes, like 500), 1000 objects moving around receiving influence from probes.

The rest of the CPU benchmarks under 3D rendering seem to be already implemented in culling.gd

I also formatted culling.gd and improved its static typing.

<details>
<summary>Results on my PC</summary>

{
	"benchmarks": [
		{
			"category": "Rendering > Culling",
			"name": "Dynamic Rotate Cull",
			"results": {
				"render_cpu": 6.082,
				"render_gpu": 2.836,
				"time": 2.812
			}
		},
		{
			"category": "Rendering > Culling",
			"name": "Dynamic Spot Light Cull With Shadows",
			"results": {
				"render_cpu": 2.44,
				"render_gpu": 3.092,
				"time": 3.426
			}
		},
		{
			"category": "Rendering > Culling",
			"name": "Static Omni Light Cull With Shadows",
			"results": {
				"render_cpu": 1.365,
				"render_gpu": 3.043,
				"time": 0.047
			}
		},
		{
			"category": "Rendering > Culling",
			"name": "Static Spot Light Cull With Shadows",
			"results": {
				"render_cpu": 1.585,
				"render_gpu": 3.063,
				"time": 0.065
			}
		},
		{
			"category": "Rendering > Lightmap Probe Influence",
			"name": "Lightmap Probe Influence",
			"results": {
				"render_cpu": 0.9369,
				"render_gpu": 3.131,
				"time": 10.8
			}
		}
	],
	"engine": {
		"version": "v4.3.beta1.official",
		"version_hash": "a4f2ea91a1bd18f70a43ff4c1377db49b56bc3f0"
	},
	"system": {
		"cpu_architecture": "x86_64",
		"cpu_count": 12,
		"cpu_name": "AMD Ryzen 5 1600 Six-Core Processor",
		"os": "Linux"
	}
}

</details>