### PR TITLE
Add tween animation benchmarks

### DIFF
--- a/benchmarks/animation/tween.gd
+++ b/benchmarks/animation/tween.gd
@@ -22,7 +22,7 @@ func tween_properties(n_of_properties: int) -> Node:
 		)
 		node2d.texture = ICON
 		node.add_child(node2d)
-		tween.parallel().tween_property(node2d, "position", viewport_size, 5)
+		tween.parallel().tween_property(node2d, "position", viewport_size / 2.0, 5)
 	return node
 
 

--- a/benchmarks/animation/tween.gd
+++ b/benchmarks/animation/tween.gd
@@ -24,6 +24,7 @@ func tween_properties(n_of_properties: int) -> Node:
 		node2d.texture = ICON
 		node.add_child(node2d)
 		tween.parallel().tween_property(node2d, "position", half_viewport_size, 5)
+
 	return node
 
 
@@ -38,6 +39,7 @@ func tween_methods(n_of_methods: int) -> Node:
 		node2d.texture = ICON
 		node.add_child(node2d)
 		tween.tween_method(node2d.rotate, 0.0, 0.01, 5)
+
 	return node
 
 

--- a/benchmarks/animation/tween.gd
+++ b/benchmarks/animation/tween.gd
@@ -1,0 +1,48 @@
+extends Benchmark
+
+const ICON := preload("res://icon.png")
+
+var viewport_size := Vector2(
+	ProjectSettings.get_setting("display/window/size/viewport_width"),
+	ProjectSettings.get_setting("display/window/size/viewport_height")
+)
+
+
+func _init() -> void:
+	test_render_cpu = true
+
+
+func tween_properties(n_of_properties: int) -> Node:
+	var node := Node.new()
+	var tween := node.create_tween()
+	for i in n_of_properties:
+		var node2d := Sprite2D.new()
+		node2d.position = Vector2(
+			randf_range(0.0, viewport_size.x), randf_range(0.0, viewport_size.y)
+		)
+		node2d.texture = ICON
+		node.add_child(node2d)
+		tween.parallel().tween_property(node2d, "position", viewport_size, 5)
+	return node
+
+
+func tween_methods(n_of_methods: int) -> Node:
+	var node := Node.new()
+	for i in n_of_methods:
+		var tween := node.create_tween()
+		var node2d := Sprite2D.new()
+		node2d.position = Vector2(
+			randf_range(0.0, viewport_size.x), randf_range(0.0, viewport_size.y)
+		)
+		node2d.texture = ICON
+		node.add_child(node2d)
+		tween.tween_method(node2d.rotate, 0, TAU, 5)
+	return node
+
+
+func benchmark_tween_100_properties() -> Node:
+	return tween_properties(100)
+
+
+func benchmark_animate_1000_tween_methods() -> Node:
+	return tween_methods(1000)

--- a/benchmarks/animation/tween.gd
+++ b/benchmarks/animation/tween.gd
@@ -6,6 +6,7 @@ var viewport_size := Vector2(
 	ProjectSettings.get_setting("display/window/size/viewport_width"),
 	ProjectSettings.get_setting("display/window/size/viewport_height")
 )
+var half_viewport_size := viewport_size / 2.0
 
 
 func _init() -> void:
@@ -22,7 +23,7 @@ func tween_properties(n_of_properties: int) -> Node:
 		)
 		node2d.texture = ICON
 		node.add_child(node2d)
-		tween.parallel().tween_property(node2d, "position", viewport_size / 2.0, 5)
+		tween.parallel().tween_property(node2d, "position", half_viewport_size, 5)
 	return node
 
 

--- a/benchmarks/animation/tween.gd
+++ b/benchmarks/animation/tween.gd
@@ -36,7 +36,7 @@ func tween_methods(n_of_methods: int) -> Node:
 		)
 		node2d.texture = ICON
 		node.add_child(node2d)
-		tween.tween_method(node2d.rotate, 0, TAU, 5)
+		tween.tween_method(node2d.rotate, 0.0, 0.01, 5)
 	return node
 
 


### PR DESCRIPTION
Adds the following benchmarks from #36:
- 🟥CPU🟥 Tweens: Animate 100 properties with a Tween
- 🟥CPU🟥 Tween Methods: Animate 1000 Tweens using tween_method().

<details>
<summary>Results on my PC</summary>

{
	{
	"benchmarks": [
		{
			"category": "Animation > Tween",
			"name": "Animate 1000 Tween Methods",
			"results": {
				"render_cpu": 0.2367,
				"time": 4.908
			}
		},
		{
			"category": "Animation > Tween",
			"name": "Tween 100 Properties",
			"results": {
				"render_cpu": 0.03256,
				"time": 0.599
			}
		}
	],
	"engine": {
		"version": "v4.3.beta1.official",
		"version_hash": "a4f2ea91a1bd18f70a43ff4c1377db49b56bc3f0"
	},
	"system": {
		"cpu_architecture": "x86_64",
		"cpu_count": 12,
		"cpu_name": "AMD Ryzen 5 1600 Six-Core Processor",
		"os": "Linux"
	}
}

</details>