### PR TITLE
Fix C# benchmarks not being able to be loaded, and implement the ability to change the benchmark time limit

### DIFF
--- a/Benchmark.cs
+++ b/Benchmark.cs
@@ -2,6 +2,7 @@ using Godot;
 
 public partial class Benchmark : RefCounted
 {
+    public double benchmark_time = 5e6;
     public bool test_render_cpu = false;
     public bool test_render_gpu = false;
     public bool test_idle = false;

--- a/benchmarks/csharp/physics/RigidBody2D.cs
+++ b/benchmarks/csharp/physics/RigidBody2D.cs
@@ -20,6 +20,7 @@ public partial class RigidBody2D : Benchmark
         SquareMesh.Size = new Vector2(20.0f, 20.0f);
         CircleMesh.Radius = 10.0f;
         CircleMesh.Height = 20.0f;
+        benchmark_time = 10e6;
         test_physics = true;
         test_idle = true;
     }

--- a/benchmarks/csharp/physics/RigidBody3D.cs
+++ b/benchmarks/csharp/physics/RigidBody3D.cs
@@ -17,6 +17,7 @@ public partial class RigidBody3D : Benchmark
 
     public RigidBody3D()
     {
+        benchmark_time = 10e6;
         test_physics = true;
         test_idle = true;
     }

--- a/manager.gd
+++ b/manager.gd
@@ -82,7 +82,7 @@ func _ready():
 	set_process(false)
 
 	# Register script language compatibility
-	if Engine.has_singleton("GodotSharp"):
+	if ClassDB.class_exists(&"CSharpScript"):
 		languages[".cs"] = {"test_prefix": "Benchmark"}
 
 	# Register contents of `benchmarks/` folder automatically.


### PR DESCRIPTION
Continuation of #73, fixes a crash when running C# physics benchmarks. Also sets the C# physics benchmarks to 10 seconds.