### PR TITLE
Fix mistakes with binary trees & spectral norm

### DIFF
--- a/benchmarks/gdscript/binary_trees.gd
+++ b/benchmarks/gdscript/binary_trees.gd
@@ -7,14 +7,14 @@ extends Benchmark
 func bottom_up_tree(depth: int) -> Array:
 	if depth > 0:
 		depth -= 1
-		var left = bottom_up_tree(depth)[0]
-		var right = bottom_up_tree(depth)[1]
+		var left = bottom_up_tree(depth)
+		var right = bottom_up_tree(depth)
 		return [left, right]
 	return [null, null]
 
 
 func item_check(tree: Array) -> int:
-	if tree[1]:
+	if tree[1] != null:
 		return 1 + item_check(tree[0]) + item_check(tree[1])
 	return 1
 
@@ -41,9 +41,9 @@ func calculate_binary_trees(n: int) -> void:
 	)
 
 
+func benchmark_binary_trees_13() -> void:
+	calculate_binary_trees(13)
+
+
 func benchmark_binary_trees_15() -> void:
 	calculate_binary_trees(15)
-
-
-func benchmark_binary_trees_18() -> void:
-	calculate_binary_trees(18)

--- a/benchmarks/gdscript/binary_trees.gd
+++ b/benchmarks/gdscript/binary_trees.gd
@@ -7,8 +7,8 @@ extends Benchmark
 func bottom_up_tree(depth: int) -> Array:
 	if depth > 0:
 		depth -= 1
-		var left = bottom_up_tree(depth)
-		var right = bottom_up_tree(depth)
+		var left := bottom_up_tree(depth)
+		var right := bottom_up_tree(depth)
 		return [left, right]
 	return [null, null]
 

--- a/benchmarks/gdscript/spectral_norm.gd
+++ b/benchmarks/gdscript/spectral_norm.gd
@@ -9,7 +9,7 @@ func eval_a(i: int, j: int) -> float:
 	return 1.0 / (ij * (ij - 1) * 0.5 + i)
 
 
-func av(x, y, n: int) -> void:
+func av(x: PackedFloat64Array, y: PackedFloat64Array, n: int) -> void:
 	for i in n:
 		var a := 0.0
 		for j in n:
@@ -17,7 +17,7 @@ func av(x, y, n: int) -> void:
 		y[i] = a
 
 
-func atv(x, y, n: int) -> void:
+func atv(x: PackedFloat64Array, y: PackedFloat64Array, n: int) -> void:
 	for i in n:
 		var a := 0.0
 		for j in n:
@@ -25,25 +25,28 @@ func atv(x, y, n: int) -> void:
 		y[i] = a
 
 
-func at_av(x, y, t, n: int) -> void:
+func at_av(x: PackedFloat64Array, y: PackedFloat64Array, t: PackedFloat64Array, n: int) -> void:
 	av(x, t, n)
 	atv(t, y, n)
 
 
 func calculate_spectral_norm(n: int) -> void:
-	var u := {}
-	var v := {}
-	var t := {}
+	var u := PackedFloat64Array([])
+	u.resize(n)
+	var v := PackedFloat64Array([])
+	v.resize(n)
+	var t := PackedFloat64Array([])
+	t.resize(n)
 	for i in n:
-		u[i] = 1
+		u[i] = 1.0
 	for i in 10:
 		at_av(u, v, t, n)
 		at_av(v, u, t, n)
 	var vbv := 0.0
 	var vv := 0.0
 	for i in n:
-		var ui = u[i]
-		var vi = v[i]
+		var ui := u[i]
+		var vi := v[i]
 		vbv += ui * vi
 		vv += vi * vi
 	print("%.9f" % sqrt(vbv / vv))

--- a/benchmarks/gdscript/spectral_norm.gd
+++ b/benchmarks/gdscript/spectral_norm.gd
@@ -33,12 +33,11 @@ func at_av(x: PackedFloat64Array, y: PackedFloat64Array, t: PackedFloat64Array, 
 func calculate_spectral_norm(n: int) -> void:
 	var u := PackedFloat64Array([])
 	u.resize(n)
+	u.fill(1.0)
 	var v := PackedFloat64Array([])
 	v.resize(n)
 	var t := PackedFloat64Array([])
 	t.resize(n)
-	for i in n:
-		u[i] = 1.0
 	for i in 10:
 		at_av(u, v, t, n)
 		at_av(v, u, t, n)

--- a/benchmarks/gdscript/spectral_norm.gd
+++ b/benchmarks/gdscript/spectral_norm.gd
@@ -50,11 +50,11 @@ func calculate_spectral_norm(n: int) -> void:
 
 
 func benchmark_spectral_norm_100() -> void:
-	calculate_spectral_norm(500)
+	calculate_spectral_norm(100)
 
 
 func benchmark_spectral_norm_500() -> void:
-	calculate_spectral_norm(1000)
+	calculate_spectral_norm(500)
 
 
 func benchmark_spectral_norm_1000() -> void:


### PR DESCRIPTION
The spectral norm algorithm benchmark implemented in #68 had the wrong inputs. My bad! 😅

EDIT: I also improved its static typing, making it run quite faster.