### PR TITLE
Add a command-line argument to toggle visuals in the physics and navigation agents benchmarks

### DIFF
--- a/benchmarks/navigation/moving_agents_2d.gd
+++ b/benchmarks/navigation/moving_agents_2d.gd
@@ -11,10 +11,12 @@ class TestScene:
 	extends Node2D
 
 	var n_of_agents: int
+	var visualize: bool
 	var agents: Array[Node2D]
 
-	func _init(_n_of_agents: int) -> void:
+	func _init(_n_of_agents: int, _visualize: bool) -> void:
 		n_of_agents = _n_of_agents
+		visualize = _visualize
 
 	func _ready() -> void:
 		var nav_region := NavigationRegion2D.new()
@@ -22,9 +24,7 @@ class TestScene:
 		add_child(nav_region)
 
 		for i in n_of_agents:
-			var agent_parent := Sprite2D.new()
-			agent_parent.scale = Vector2(0.1, 0.1)
-			agent_parent.texture = ICON
+			var agent_parent := Node2D.new()
 			agent_parent.position = _rand_pos()
 			var agent := NavigationAgent2D.new()
 			agent.avoidance_enabled = true
@@ -32,6 +32,11 @@ class TestScene:
 			agent_parent.add_child(agent)
 			add_child(agent_parent)
 			agents.append(agent_parent)
+			if visualize:
+				var sprite := Sprite2D.new()
+				sprite.scale = Vector2(0.1, 0.1)
+				sprite.texture = ICON
+				agent_parent.add_child(sprite)
 
 	func _physics_process(delta: float) -> void:
 		if NavigationServer2D.map_get_iteration_id(get_world_2d().navigation_map) == 0:
@@ -54,4 +59,4 @@ func _init() -> void:
 
 
 func benchmark_1000_moving_agents() -> TestScene:
-	return TestScene.new(1000)
+	return TestScene.new(1000, true)

--- a/benchmarks/navigation/moving_agents_2d.gd
+++ b/benchmarks/navigation/moving_agents_2d.gd
@@ -59,4 +59,4 @@ func _init() -> void:
 
 
 func benchmark_1000_moving_agents() -> TestScene:
-	return TestScene.new(1000, true)
+	return TestScene.new(1000, false)

--- a/benchmarks/navigation/moving_agents_2d.gd
+++ b/benchmarks/navigation/moving_agents_2d.gd
@@ -11,12 +11,10 @@ class TestScene:
 	extends Node2D
 
 	var n_of_agents: int
-	var visualize: bool
 	var agents: Array[Node2D]
 
-	func _init(_n_of_agents: int, _visualize: bool) -> void:
+	func _init(_n_of_agents: int) -> void:
 		n_of_agents = _n_of_agents
-		visualize = _visualize
 
 	func _ready() -> void:
 		var nav_region := NavigationRegion2D.new()
@@ -32,7 +30,7 @@ class TestScene:
 			agent_parent.add_child(agent)
 			add_child(agent_parent)
 			agents.append(agent_parent)
-			if visualize:
+			if Manager.visualize:
 				var sprite := Sprite2D.new()
 				sprite.scale = Vector2(0.1, 0.1)
 				sprite.texture = ICON
@@ -59,4 +57,4 @@ func _init() -> void:
 
 
 func benchmark_1000_moving_agents() -> TestScene:
-	return TestScene.new(1000, false)
+	return TestScene.new(1000)

--- a/benchmarks/navigation/moving_agents_3d.gd
+++ b/benchmarks/navigation/moving_agents_3d.gd
@@ -12,14 +12,19 @@ class TestScene:
 
 	var sponza: Node
 	var n_of_agents: int
+	var visualize: bool
 	var agents: Array[Node3D]
 
-	func _init(_n_of_agents: int) -> void:
+	func _init(_n_of_agents: int, _visualize: bool) -> void:
 		n_of_agents = _n_of_agents
+		visualize = _visualize
 
 	func _ready() -> void:
 		sponza = SPONZA_SCENE.instantiate()
 		add_child(sponza)
+		sponza.get_node("DirectionalLight3D").queue_free()
+		sponza.get_node("OmniLights").queue_free()
+		sponza.get_node("Camera3D").current = visualize
 		var nav_region := NavigationRegion3D.new()
 		nav_region.navigation_mesh = NAVMESH
 		sponza.add_child(nav_region)
@@ -34,17 +39,19 @@ class TestScene:
 		mesh.material = material
 
 		for i in n_of_agents:
-			var agent_parent := MeshInstance3D.new()
-			agent_parent.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
-			agent_parent.mesh = mesh
+			var agent_parent := Node3D.new()
 			agent_parent.position = _rand_pos()
-
 			var agent := NavigationAgent3D.new()
 			agent.avoidance_enabled = true
 			agent.target_position = _rand_pos()
 			agent_parent.add_child(agent)
 			sponza.add_child(agent_parent)
 			agents.append(agent_parent)
+			if visualize:
+				var mesh_instance := MeshInstance3D.new()
+				mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
+				mesh_instance.mesh = mesh
+				agent_parent.add_child(mesh_instance)
 
 	func _physics_process(delta: float) -> void:
 		if NavigationServer3D.map_get_iteration_id(get_world_3d().navigation_map) == 0:
@@ -71,4 +78,4 @@ func _init() -> void:
 
 
 func benchmark_1000_moving_agents() -> TestScene:
-	return TestScene.new(1000)
+	return TestScene.new(1000, true)

--- a/benchmarks/navigation/moving_agents_3d.gd
+++ b/benchmarks/navigation/moving_agents_3d.gd
@@ -78,4 +78,4 @@ func _init() -> void:
 
 
 func benchmark_1000_moving_agents() -> TestScene:
-	return TestScene.new(1000, true)
+	return TestScene.new(1000, false)

--- a/benchmarks/navigation/moving_agents_3d.gd
+++ b/benchmarks/navigation/moving_agents_3d.gd
@@ -12,19 +12,17 @@ class TestScene:
 
 	var sponza: Node
 	var n_of_agents: int
-	var visualize: bool
 	var agents: Array[Node3D]
 
-	func _init(_n_of_agents: int, _visualize: bool) -> void:
+	func _init(_n_of_agents: int) -> void:
 		n_of_agents = _n_of_agents
-		visualize = _visualize
 
 	func _ready() -> void:
 		sponza = SPONZA_SCENE.instantiate()
 		add_child(sponza)
 		sponza.get_node("DirectionalLight3D").queue_free()
 		sponza.get_node("OmniLights").queue_free()
-		sponza.get_node("Camera3D").current = visualize
+		sponza.get_node("Camera3D").current = Manager.visualize
 		var nav_region := NavigationRegion3D.new()
 		nav_region.navigation_mesh = NAVMESH
 		sponza.add_child(nav_region)
@@ -47,7 +45,7 @@ class TestScene:
 			agent_parent.add_child(agent)
 			sponza.add_child(agent_parent)
 			agents.append(agent_parent)
-			if visualize:
+			if Manager.visualize:
 				var mesh_instance := MeshInstance3D.new()
 				mesh_instance.cast_shadow = GeometryInstance3D.SHADOW_CASTING_SETTING_OFF
 				mesh_instance.mesh = mesh
@@ -78,4 +76,4 @@ func _init() -> void:
 
 
 func benchmark_1000_moving_agents() -> TestScene:
-	return TestScene.new(1000, false)
+	return TestScene.new(1000)

--- a/benchmarks/physics/area_2d.gd
+++ b/benchmarks/physics/area_2d.gd
@@ -6,7 +6,6 @@ class TestScene:
 
 	var num_character_bodies: int
 	var num_area_2d: int
-	var visualize := true
 	var area_2d_nodes: Array[Area2D]
 	var window_size: Vector2i
 	var time_accum := 0.0
@@ -21,10 +20,9 @@ class TestScene:
 		SphereMesh.new(),
 	]
 
-	func _init(_num_character_bodies: int, _num_area_2d: int, _visualize: bool) -> void:
+	func _init(_num_character_bodies: int, _num_area_2d: int) -> void:
 		num_character_bodies = _num_character_bodies
 		num_area_2d = _num_area_2d
-		visualize = _visualize
 
 		meshes[0].size = Vector2(20.0, 20.0)
 		meshes[1].radius = 10.0
@@ -60,7 +58,7 @@ class TestScene:
 		var r := randi() % shapes.size()
 		var collision_shape := CollisionShape2D.new()
 		collision_shape.shape = shapes[r]
-		if visualize:
+		if Manager.visualize:
 			var mesh_instance := MeshInstance2D.new()
 			mesh_instance.mesh = meshes[r]
 			parent.add_child(mesh_instance)
@@ -74,4 +72,4 @@ func _init() -> void:
 
 
 func benchmark_1000_area_2d() -> TestScene:
-	return TestScene.new(2000, 1000, true)
+	return TestScene.new(2000, 1000)

--- a/benchmarks/physics/area_3d.gd
+++ b/benchmarks/physics/area_3d.gd
@@ -9,7 +9,6 @@ class TestScene:
 
 	var num_character_bodies: int
 	var num_area_3d: int
-	var visualize := true
 	var area_3d_nodes: Array[Area3D]
 	var time_accum := 0.0
 	var shapes: Array[Shape3D] = [
@@ -23,13 +22,12 @@ class TestScene:
 		SphereMesh.new(),
 	]
 
-	func _init(_num_character_bodies: int, _num_area_3d: int, _visualize: bool) -> void:
+	func _init(_num_character_bodies: int, _num_area_3d: int) -> void:
 		num_character_bodies = _num_character_bodies
 		num_area_3d = _num_area_3d
-		visualize = _visualize
 
 	func _ready() -> void:
-		if visualize:
+		if Manager.visualize:
 			var camera := Camera3D.new()
 			camera.position = Vector3(0.0, 20.0, 20.0)
 			camera.rotate_x(-0.8)
@@ -64,7 +62,7 @@ class TestScene:
 		var r := randi() % shapes.size()
 		var collision_shape := CollisionShape3D.new()
 		collision_shape.shape = shapes[r]
-		if visualize:
+		if Manager.visualize:
 			var mesh_instance := MeshInstance3D.new()
 			mesh_instance.mesh = meshes[r]
 			parent.add_child(mesh_instance)
@@ -78,4 +76,4 @@ func _init() -> void:
 
 
 func benchmark_1000_area_3d() -> TestScene:
-	return TestScene.new(2000, 1000, true)
+	return TestScene.new(2000, 1000)

--- a/benchmarks/physics/character_body_2d.gd
+++ b/benchmarks/physics/character_body_2d.gd
@@ -10,14 +10,12 @@ class TestScene:
 	var tile_map_scene := preload("res://supplemental/tilemap_scene.tscn")
 	var tile_map_node: Node2D
 	var n_of_character_bodies: int
-	var visualize := true
 	var character_bodies: Array[CharacterBody2D] = []
 	var capsule_mesh := CapsuleMesh.new()
 	var window_size: Vector2i
 
-	func _init(_n_of_character_bodies: int, _visualize: bool) -> void:
+	func _init(_n_of_character_bodies: int) -> void:
 		n_of_character_bodies = _n_of_character_bodies
-		visualize = _visualize
 		capsule_mesh.radius = 10.0
 		capsule_mesh.height = 28.0
 
@@ -33,7 +31,7 @@ class TestScene:
 			var collision_shape := CollisionShape2D.new()
 			collision_shape.shape = CapsuleShape2D.new()
 			body.add_child(collision_shape)
-			if visualize:
+			if Manager.visualize:
 				var mesh_instance := MeshInstance2D.new()
 				mesh_instance.mesh = capsule_mesh
 				body.add_child(mesh_instance)
@@ -64,4 +62,4 @@ func _init() -> void:
 
 
 func benchmark_1000_character_bodies_2d() -> TestScene:
-	return TestScene.new(1000, true)
+	return TestScene.new(1000)

--- a/benchmarks/physics/character_body_3d.gd
+++ b/benchmarks/physics/character_body_3d.gd
@@ -12,13 +12,11 @@ class TestScene:
 	var grid_map_scene := preload("res://supplemental/gridmap_scene.tscn")
 	var grid_map_node: Node3D
 	var n_of_character_bodies: int
-	var visualize := true
 	var character_bodies: Array[CharacterBody3D] = []
 	var capsule_mesh := CapsuleMesh.new()
 
-	func _init(_n_of_character_bodies: int, _visualize: bool) -> void:
+	func _init(_n_of_character_bodies: int) -> void:
 		n_of_character_bodies = _n_of_character_bodies
-		visualize = _visualize
 
 	func _ready() -> void:
 		grid_map_node = grid_map_scene.instantiate()
@@ -32,7 +30,7 @@ class TestScene:
 			var collision_shape := CollisionShape3D.new()
 			collision_shape.shape = CapsuleShape3D.new()
 			body.add_child(collision_shape)
-			if visualize:
+			if Manager.visualize:
 				var mesh_instance := MeshInstance3D.new()
 				mesh_instance.mesh = capsule_mesh
 				body.add_child(mesh_instance)
@@ -63,4 +61,4 @@ func _init() -> void:
 
 
 func benchmark_1000_character_bodies_3d() -> TestScene:
-	return TestScene.new(1000, true)
+	return TestScene.new(1000)

--- a/benchmarks/physics/rigid_body_2d.gd
+++ b/benchmarks/physics/rigid_body_2d.gd
@@ -1,6 +1,5 @@
 extends Benchmark
 
-const VISUALIZE := true
 const SPREAD_H := 1600.0;
 const SPREAD_V := 800.0;
 
@@ -22,7 +21,7 @@ func _init() -> void:
 func setup_scene(create_body_func: Callable, unique_shape: bool, ccd_mode: RigidBody2D.CCDMode, boundary: bool, num_shapes: int) -> Node2D:
 	var scene_root := Node2D.new()
 
-	if VISUALIZE:
+	if Manager.visualize:
 		var camera := Camera2D.new()
 		camera.position = Vector2(0.0, -100.0)
 		camera.zoom = Vector2(0.5, 0.5)
@@ -61,7 +60,7 @@ func create_square(unique_shape: bool, ccd_mode: RigidBody2D.CCDMode) -> RigidBo
 	var collision_shape := CollisionShape2D.new()
 	rigid_body.continuous_cd = ccd_mode
 
-	if VISUALIZE:
+	if Manager.visualize:
 		var mesh_instance := MeshInstance2D.new()
 		mesh_instance.mesh = square_mesh
 		rigid_body.add_child(mesh_instance)
@@ -81,7 +80,7 @@ func create_circle(unique_shape: bool, ccd_mode: RigidBody2D.CCDMode) -> RigidBo
 	var collision_shape := CollisionShape2D.new()
 	rigid_body.continuous_cd = ccd_mode
 
-	if VISUALIZE:
+	if Manager.visualize:
 		var mesh_instance := MeshInstance2D.new()
 		mesh_instance.mesh = circle_mesh
 		rigid_body.add_child(mesh_instance)

--- a/benchmarks/physics/rigid_body_3d.gd
+++ b/benchmarks/physics/rigid_body_3d.gd
@@ -1,6 +1,6 @@
 extends Benchmark
 
-const VISUALIZE := true
+
 const SPREAD_H := 20.0;
 const SPREAD_V := 10.0;
 
@@ -19,7 +19,7 @@ func _init() -> void:
 func setup_scene(create_body_func: Callable, unique_shape: bool, ccd_mode: bool, boundary: bool, num_shapes: int) -> Node3D:
 	var scene_root := Node3D.new()
 
-	if VISUALIZE:
+	if Manager.visualize:
 		var camera := Camera3D.new()
 		camera.position = Vector3(0.0, 20.0, 20.0)
 		camera.rotate_x(-0.8)
@@ -60,7 +60,7 @@ func create_box(unique_shape: bool, ccd_mode: bool) -> RigidBody3D:
 	var collision_shape := CollisionShape3D.new()
 	rigid_body.continuous_cd = ccd_mode
 
-	if VISUALIZE:
+	if Manager.visualize:
 		var mesh_instance := MeshInstance3D.new()
 		mesh_instance.mesh = box_mesh
 		rigid_body.add_child(mesh_instance)
@@ -80,7 +80,7 @@ func create_sphere(unique_shape: bool, ccd_mode: bool) -> RigidBody3D:
 	var collision_shape := CollisionShape3D.new()
 	rigid_body.continuous_cd = ccd_mode
 
-	if VISUALIZE:
+	if Manager.visualize:
 		var mesh_instance := MeshInstance3D.new()
 		mesh_instance.mesh = sphere_mesh
 		rigid_body.add_child(mesh_instance)

--- a/benchmarks/physics/softbody_3d.gd
+++ b/benchmarks/physics/softbody_3d.gd
@@ -8,7 +8,6 @@ class TestScene:
 	extends Node3D
 
 	var n_of_rigidbodies: int
-	var visualize := true
 	var shapes: Array[Shape3D] = [
 		BoxShape3D.new(),
 		CapsuleShape3D.new(),
@@ -20,9 +19,8 @@ class TestScene:
 		SphereMesh.new(),
 	]
 
-	func _init(_n_of_rigidbodies: int, _visualize: bool) -> void:
+	func _init(_n_of_rigidbodies: int) -> void:
 		n_of_rigidbodies = _n_of_rigidbodies
-		visualize = _visualize
 
 	func _ready() -> void:
 		var softbody := SoftBody3D.new()
@@ -36,7 +34,7 @@ class TestScene:
 		softbody.set_point_pinned(275, true)
 		softbody.set_point_pinned(517, true)
 		add_child(softbody)
-		if visualize:
+		if Manager.visualize:
 			var camera := Camera3D.new()
 			camera.position = Vector3(0.0, 20.0, 20.0)
 			camera.rotate_x(-0.8)
@@ -56,7 +54,7 @@ class TestScene:
 		var r := randi() % shapes.size()
 		var collision_shape := CollisionShape3D.new()
 		collision_shape.shape = shapes[r]
-		if visualize:
+		if Manager.visualize:
 			var mesh_instance := MeshInstance3D.new()
 			mesh_instance.mesh = meshes[r]
 			parent.add_child(mesh_instance)
@@ -70,4 +68,4 @@ func _init() -> void:
 
 
 func benchmark_softbody_3d_500_rigidbodies() -> TestScene:
-	return TestScene.new(500, true)
+	return TestScene.new(500)

--- a/benchmarks/physics/triangle_mesh.gd
+++ b/benchmarks/physics/triangle_mesh.gd
@@ -9,7 +9,6 @@ class TestScene:
 
 	var collision_scene := preload("res://supplemental/8ball.glb")
 	var n_of_rigidbodies: int
-	var visualize := true
 	var shapes: Array[Shape3D] = [
 		BoxShape3D.new(),
 		CapsuleShape3D.new(),
@@ -21,16 +20,15 @@ class TestScene:
 		SphereMesh.new(),
 	]
 
-	func _init(_n_of_rigidbodies: int, _visualize: bool) -> void:
+	func _init(_n_of_rigidbodies: int) -> void:
 		n_of_rigidbodies = _n_of_rigidbodies
-		visualize = _visualize
 
 	func _ready() -> void:
 		var collision_node := collision_scene.instantiate() as Node3D
 		collision_node.rotate_y(PI / 2.0)
 		collision_node.scale = Vector3(7, 7, 7)
 		add_child(collision_node)
-		if visualize:
+		if Manager.visualize:
 			var camera := Camera3D.new()
 			camera.position = Vector3(0.0, 20.0, 20.0)
 			camera.rotate_x(-0.8)
@@ -49,7 +47,7 @@ class TestScene:
 		var r := randi() % shapes.size()
 		var collision_shape := CollisionShape3D.new()
 		collision_shape.shape = shapes[r]
-		if visualize:
+		if Manager.visualize:
 			var mesh_instance := MeshInstance3D.new()
 			mesh_instance.mesh = meshes[r]
 			parent.add_child(mesh_instance)
@@ -63,4 +61,4 @@ func _init() -> void:
 
 
 func benchmark_triangle_mesh_3d_1000_rigidbodies() -> TestScene:
-	return TestScene.new(1000, true)
+	return TestScene.new(1000)

--- a/main.gd
+++ b/main.gd
@@ -8,6 +8,7 @@ var arg_exclude_benchmarks := ""
 var arg_save_json := ""
 var arg_json_results_prefix := ""
 var arg_run_benchmarks := false
+var arg_visualize := false
 
 @onready var tree := $Tree as Tree
 var categories := {}
@@ -34,6 +35,7 @@ func _ready() -> void:
 
 		print("Variable %s set by command line to %s" % [var_name, self.get(var_name)])
 
+	Manager.visualize = arg_visualize
 	# No point in copying JSON without any results yet.
 	$CopyJSON.visible = false
 

--- a/manager.gd
+++ b/manager.gd
@@ -56,6 +56,7 @@ var test_results := {}
 
 var save_json_to_path := ""
 var json_results_prefix := ""
+var visualize := false
 
 
 ## Recursively walks the given directory and returns all files found


### PR DESCRIPTION
To make it easier to just check CPU usage of the navigation system itself, without visuals. ~~The visuals are enabled by default, like they are in the physics benchmarks, but I can make them disabled if desired.~~ EDIT: They are now off by default.