### PR TITLE
Doc: Specify `--import` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ You can save the results JSON to a file using `--save-json="path/to/file.json"`
 
 > **Note**
 >
-> To import the project in the editor from the command line, use `godot --editor --quit`.
-> If this doesn't work, use `timeout 30 godot --editor`.
+> To import the project in the editor from the command line, use `godot --import`.
 
 > **Note**
 >


### PR DESCRIPTION
Changes the readme's CI import example to `godot --import`. Old syntax is redundant after godotengine/godot#90431.

It's possible some commands in `run-benchmarks.sh` could be adjusted to utilize this new syntax as well, but I'm not as familiar with how it operates so I've left it alone for now.