### PR TITLE
Show the 10 most recent benchmarks on the homepage only at first

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -7,14 +7,12 @@ which runs benchmarks on a dedicated server with various GPU models.
 ## How it works
 
 - Using the [`run-benchmarks.sh` script](../run-benchmarks.sh), benchmark data
-  is collected and saved to a single JSON file for each engine commit, with 5 runs:
+  is collected and saved to a single JSON file for each engine commit, with 4 runs:
   - CPU (debug template)
   - CPU (release template)
   - GPU (AMD, release template)
-<!--
   - GPU (Intel, release template)
-  - GPU (NVIDIA, release template)
--->
+  <!-- - GPU (NVIDIA, release template) -->
 - The produced results (as .json or .md) should be copied into the `src-data/benchmarks` folder.
 - The [./generate-content.py script](./generate-content.py) produces `.md` files
   in the `content` folder, so that web pages can be generated for each graph and each benchmark.
@@ -25,20 +23,20 @@ which runs benchmarks on a dedicated server with various GPU models.
 - [Water.css](https://watercss.kognise.dev/) is used to provide styling,
   including automatic dark theme support.
 
-### Building
+## Building
 
-## Development
+### Development
 
-- Create JSON data or fetch existing JSON data from the live website, and copy the JSON files into 
-  the `src-data/benchmarks` folder. Files should be named using format `YYYY-MM-DD_hash.json` where 
-  `hash` is a 9-character Git commit hash of the Godot build used (truncated from a full commit hash).
-  The files can also have the `.md` extension (for backward compatibility), but they should still be 
-  JSON inside.
-- Run [./generate-content.py](./generate-content.py). This should create `.md` pages in both the 
+- Create JSON data or [fetch existing JSON data from the live website](https://github.com/godotengine/godot-benchmarks-results),
+  and copy the JSON files into the `src-data/benchmarks` folder. Files should be named using format
+  `YYYY-MM-DD_hash.json` where `hash` is a 9-character Git commit hash of the Godot build used
+  (truncated from a full commit hash). The files can also have the `.md` extension
+  (for backward compatibility), but they should still be JSON inside.
+- Run [./generate-content.py](./generate-content.py). This should create `.md` pages in both the
   `content/benchmark` and the `content/graph` folders.
 - Run `hugo server`.
 
-## Production
+### Production
 
 - Follow the same steps as in the **Development** section above.
 - Run `hugo --minify`.

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -33,8 +33,16 @@
   </div>
 
   <h2>Latest benchmark runs</h2>
-  <ul>
-    {{ range sort $benchmarks ".date" "asc" | first 100}}
+  <ul id="recent-benchmarks">
+    {{ range sort $benchmarks ".date" "desc" | first 10}}
+      <li>
+        <a href="/benchmark/{{ .date }}_{{ .commit }}">{{ .date }}<code>{{ slicestr .engine.version_hash 0 9 }}</code></a>
+      </li>
+    {{ end }}
+      <li><a onclick="showAllBenchmarks()" style="cursor: pointer">Show all benchmarks...</a></li>
+  </ul>
+  <ul id="all-benchmarks" style="display: none">
+    {{ range sort $benchmarks ".date" "desc"}}
       <li>
         <a href="/benchmark/{{ .date }}_{{ .commit }}">{{ .date }}<code>{{ slicestr .engine.version_hash 0 9 }}</code></a>
       </li>
@@ -99,11 +107,16 @@
 <script>
   // Update all graphs.
   function updateGraphs() {
-    let selectTag = document.querySelector('#metric');
-    Database.graphs.forEach((g) => {
-      displayGraph(`#${g.id}`, g.id, "compact")
+    let selectTag = document.querySelector("#metric");
+    Database.graphs.forEach((graph) => {
+      displayGraph(`#${graph.id}`, graph.id, "compact");
     })
   }
-  updateGraphs()
+  updateGraphs();
+
+  function showAllBenchmarks() {
+    document.getElementById("recent-benchmarks").style.display = "none";
+    document.getElementById("all-benchmarks").style.display = "block";
+  }
 </script>
 {{ end }}


### PR DESCRIPTION
The user can click "Show all benchmarks..." at the end to reveal the full list of benchmarks.

Benchmarks are also now ordered from newest to oldest, instead of from oldest to newest.

- This closes https://github.com/godotengine/godot-benchmarks/issues/91.

## Preview

![List of benchmarks](https://github.com/user-attachments/assets/bdaa64e0-52d6-4c3f-91b2-517ee299630f)
