### PR TITLE
Add compile_commands.json to gitignore.

### DIFF
--- a/gdextension/.gitignore
+++ b/gdextension/.gitignore
@@ -17,3 +17,6 @@
 *.files
 *.includes
 *.idb
+
+# Generated Files
+/compile_commands.json

--- a/gdextension/.gitignore
+++ b/gdextension/.gitignore
@@ -18,5 +18,5 @@
 *.includes
 *.idb
 
-# Generated Files
+# SCons-generated files
 /compile_commands.json


### PR DESCRIPTION
`compile_commands.json` is required for many IDEs and can be generated using `scons compiledb=yes compile_commands.json`.