### PR TITLE
Use int64_t instead of long for int64 TypedArray.

### DIFF
--- a/gdextension/src/benchmarks/array.cpp
+++ b/gdextension/src/benchmarks/array.cpp
@@ -38,7 +38,7 @@ void CPPBenchmarkArray::benchmark_int32_array() {
 }
 
 void CPPBenchmarkArray::benchmark_int64_array() {
-	TypedArray<long> array;
+	TypedArray<int64_t> array;
 
     for(int i = 0; i < iterations; i++)
         array.push_back(i);


### PR DESCRIPTION
Fixes compile issues on macOS `arm64` / clang:

```
In file included from godot-cpp/gen/include/godot_cpp/classes/object.hpp:41:
godot-cpp/include/godot_cpp/variant/typed_array.hpp:58:30: error: type 'long' cannot be used prior to '::' because it has no members
   58 |                 set_typed(Variant::OBJECT, T::get_class_static(), Variant());
      |                                            ^
src/benchmarks/array.cpp:41:19: note: in instantiation of member function 'godot::TypedArray<long>::TypedArray' requested here
   41 |         TypedArray<long> array;
      |                          ^
1 error generated.
scons: *** [src/benchmarks/array.os] Error 1
scons: building terminated because of errors.
```