### PR TITLE
Remove include of non-standard and not needed `<malloc.h>`

### DIFF
--- a/gdextension/src/benchmarks/spectral_norm.cpp
+++ b/gdextension/src/benchmarks/spectral_norm.cpp
@@ -3,8 +3,6 @@
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
-#include <malloc.h>
-
 using namespace godot;
 
 void CPPBenchmarkSpectralNorm::_bind_methods() {


### PR DESCRIPTION
Fixes #102.