### PR TITLE
Fix cannot detect benchmarks in exported version

### DIFF
--- a/manager.gd
+++ b/manager.gd
@@ -44,6 +44,9 @@ class TestID:
 func test_ids_from_path(path: String) -> Array[TestID]:
 	var rv : Array[TestID] = []
 
+	# Recognize paths in an exported project correctly.
+	path = path.trim_suffix(".remap")
+
 	# Check for runnable tests.
 	for extension in languages.keys():
 		if not path.ends_with(extension):


### PR DESCRIPTION
I encountered this bug while trying to export to web. The exported project couldn't recognize benchmarks because Godot remaps resource paths, which resulted in the script paths got from `DirAccess` having a `.remap` suffix. Adding a simple filter fixed the issue.