### PR TITLE
Fix sorting on Chromium-based browsers

### DIFF
--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -15,9 +15,6 @@
   <div style="display: flex; align-items: center; margin-bottom: 1em;">
     <div style="flex-grow: 3;">
       Normalized (percentage of the average time). <strong>Lower is better on all graphs.</strong>
-      <p>
-        <strong>⚠️ There are <a href="https://github.com/godotengine/godot-benchmarks/issues/87">known issues</a> with graph sorting in Chromium-based browsers. Please use Firefox for now. ⚠️</strong>
-      </p>
     </div>
   </div>
   <div style="display: grid; grid-template-columns: 50% 50%; gap: 1em;">

--- a/web/static/graphs.js
+++ b/web/static/graphs.js
@@ -17,7 +17,7 @@ function displayGraph(targetDivID, graphID, type = "full", filter = "") {
 
 	// Include benchmark data JSON to generate graphs.
 	const allBenchmarks = Database.benchmarks.sort(
-		(a, b) => `${a.date}.${a.commit}` > `${b.date}.${b.commit}`,
+		(a, b) => `${a.date}.${a.commit}` > `${b.date}.${b.commit}` ? 1 : -1,
 	);
 	const graph = Database.graphs.find((g) => g.id == graphID);
 	if (!graph) {


### PR DESCRIPTION
This PR fixes the call to `sort()` on Chromium-based browsers, while having no further effect on Firefox (which was working previously).

Tested on MacOS Sequoia Version 15.2 (24C101), with:

1. Chrome - Version 132.0.6834.160 (Official Build) (arm64)
2. Firefox - 129.0.2 (64-bit)

The fix was inspired by freeCodeCamp/freeCodeCamp#34543 .

The Chrome (left) and Firefox (right) browsers are shown side by side below...

For the fixed code (correct behaviour)

<img width="1512" alt="fixed branch" src="https://github.com/user-attachments/assets/274c0ed3-5c67-4faa-bed6-ad9205f7b3dc" />

For the `main` branch (incorrect sorting only for Chrome)

<img width="1512" alt="Screenshot 2025-02-04 at 14 27 36" src="https://github.com/user-attachments/assets/8d3a746a-19aa-432c-926d-51ab65f1c575" />


