### PR TITLE
Re-added missing header needed for Windows

### DIFF
--- a/gdextension/src/benchmarks/spectral_norm.cpp
+++ b/gdextension/src/benchmarks/spectral_norm.cpp
@@ -3,6 +3,10 @@
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
+#if defined(_WIN32) || defined(_WIN64)
+#include <malloc.h>
+#endif
+
 using namespace godot;
 
 void CPPBenchmarkSpectralNorm::_bind_methods() {


### PR DESCRIPTION
PR #103 broke windows builds. The header has been re-added with a preprocessor conditional check for Windows.