### PR TITLE
Add vlines for Godot release dates.

### DIFF
--- a/web/static/graphs.js
+++ b/web/static/graphs.js
@@ -10,6 +10,11 @@ function getAllowedMetrics() {
 	return allowedMetrics;
 }
 
+const godotReleaseDates = {
+	"2024-08-15": "4.3",
+	"2025-03-03": "4.4",
+};
+
 // Themes extracted using https://stackoverflow.com/questions/71721049/react-plotly-js-apply-dark-plotly-dark-theme
 // Derives from plotly
 const plotlyTemplatePlotly = {
@@ -1196,6 +1201,28 @@ function displayGraph(targetDivID, graphID, type = "full", filter = "") {
 		},
 		height: type === "compact" ? 150 : 500,
 		template: prefersDark ? plotlyTemplatePlotlyDark : plotlyTemplatePlotly,
+		shapes: Object.entries(godotReleaseDates).map(([date, name]) => ({
+			name,
+			type: 'line',
+			x0: date,
+			y0: 0,
+			x1: date,
+			yref: 'paper',
+			y1: 1,
+			line: {
+				color: 'grey',
+				width: type === "compact" ? 1.0 : 1.5,
+				dash: 'dot'
+			}
+		})),
+		annotations: Object.entries(godotReleaseDates).map(([date, name]) => ({
+			xanchor: 'right',
+			x: date,
+			y: 1,
+			yref: 'paper',
+			text: name + " ",
+			showarrow: false,
+		}))
 	};
 
 	// Initialize Plotly.js plot


### PR DESCRIPTION
This commit adds vlines for Godot releases to add some context to the time line.

I omitted this from #117 because it's a debatable new feature.

If merged, we'll need to keep the releases up to date manually. Since Godot only releases up to 3 times a year currently, I don't think this is a huge blocker.

<img width="1301" height="515" alt="SCR-20250820-cjbb" src="https://github.com/user-attachments/assets/9311caf5-248e-4fbe-9666-70a8dc59e187" />

<img width="1243" height="633" alt="SCR-20250820-cjla" src="https://github.com/user-attachments/assets/88ea89e3-b42c-4150-8d9e-f5fb145b7bc8" />
