### PR TITLE
In the overview, use the median, iqr, and interquartile range

### DIFF
--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -14,7 +14,14 @@
   <h2>Graphs</h2>
   <div style="display: flex; align-items: center; margin-bottom: 1em;">
     <div style="flex-grow: 3;">
-      Normalized (percentage of the average time). <strong>Lower is better on all graphs.</strong>
+      <p>
+        Normalized (percentage of the average time). <strong>Lower is better on all graphs.</strong>
+      </p>
+      <p>
+        The middle line is the <strong>median</strong> of all benchmarks in each category.
+        The inner range is the <strong>interquartile range (IQR)</strong>.
+        The outer range is the total range (<strong>minimum</strong> and <strong>maximum</strong>).
+      </p>
     </div>
   </div>
   <div style="display: grid; grid-template-columns: 33% 33% 33%; gap: 2em;">


### PR DESCRIPTION
This is common in summary plots like this.

- The **median** (50th percentile) is more appropriate than the **mean** (previously used) because it is more robust to outliers.
- The **IQR** (interquartile range) shows the spread of the bulk (middle 50%) of the data. It uses the 25th percentile and 75th percentile.
- The **min** / **max** show the total spread of the data. It uses the min (0th percentile) and max (100th percentile).

<img width="1296" height="820" alt="SCR-20250820-kioa" src="https://github.com/user-attachments/assets/11ef6875-fd55-4982-b20d-60ce16ba4502" />
