### PR TITLE
Update contributing links and migrate contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,76 +2,10 @@
 
 Thank you for your interest in contributing!
 
+Please visit the [Contributing docs](https://contributing.godotengine.org/en/latest/other/benchmarks.html) to learn how to contribute.
+
 > [!NOTE]
 >
 > This project only supports Godot's `master` branch (4.x's development branch),
 > not Godot 3.x.
 > Attempting to open this project in Godot 3.x will result in errors.
-
-## Adding new benchmarks
-
-You can add new test cases by following these steps:
-
-### Create new benchmark
-
-Create a new script with `snake_case` naming that `extends Benchmark`,
-then save it in one of the existing folders depending on its category.
-If your benchmark does not suit any existing category or subcategory,
-you can also create a new folder in the repository's root folder.
-
-### Configure the benchmark
-
-In the `_init()` function of your script, configure your benchmark by
-initializing any desired `Benchmark` variables to true:
-
-- `test_render_cpu`: Enable this for rendering benchmarks.
-  Leave it disabled for other benchmarks.
-- `test_render_gpu`: Enable this for rendering benchmarks.
-  Leave it disabled for other benchmarks.
-- `test_idle`: Enable this for non-rendering CPU-intensive benchmarks.
-  Leave it disabled for other benchmarks.
-- `test_physics`: Enable this for physics benchmarks.
-  Leave it disabled for other benchmarks.
-- > Leaving all of these disabled will only time the initial call to your `benchmark_` function (see below).
-
-### Implement the benchmark
-
-The runtime will scan your script for functions beginning with `benchmark_`.
-For basic benchmarks, writing your code inside such a function is sufficient for it
-to be automatically registered and become available for benchmarking by the user.
-The runtime will end the benchmark once your function returns
-and report the amount of time spent running inside it.
-
-For more advanced benchmarks, the runtime expects the function to return a `Node`.
-Return the appropriate node for your benchmark[^1] to signal to the runtime
-that it should continue measuring system resource usage even after your function returns.
-The runtime will add your node to the scene as a root node,
-leave it running for a fixed amount of time (currently 5 seconds),
-and then end the benchmark and report the various metrics configured above.
-
-[^1]: For 3D rendering benchmarks, the root node should be Node3D. For 2D
-rendering benchmarks, the root node should be Node2D. For UI benchmarks, the
-root node should be Control. For scripting or miscellaneous benchmarks, the root
-node should be Node.
-
-Remember to follow the
-[GDScript style guide](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_styleguide.html)
-when writing new scripts. Adding type hints is recommended whenever possible,
-unless you are specifically benchmarking non-typed scripts.
-
-> [!NOTE]
->
-> C# benchmark functions must begin with `Benchmark`, instead of `benchmark_`.
-> For C# benchmarks to be available, you must use the .NET version of the engine.
-
-### Test the benchmark
-
-1. Run the project in the editor.
-2. Check the checkbox next to your newly added benchmark and click **Run** in the
-   bottom-right corner.
-3. Wait for the benchmark to complete.
-4. If all goes well, the benchmark completion time should appear in the table for
-   all enabled benchmarks (and all relevant metrics). Metrics that were disabled
-   on a specific benchmarks will not display any result.
-
-If the benchmark works as expected, congratulations! You can now open a pull request for it 🙂

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Godot project that stores and runs a collection of benchmarks. It is
 used to test performance of different areas of [Godot](https://godotengine.org)
 such as rendering and scripting.
 
-**Interested in adding new benchmarks?** See [CONTRIBUTING.md](CONTRIBUTING.md).
+**Interested in adding new benchmarks?** See the [Contributing docs](https://contributing.godotengine.org/en/latest/other/benchmarks.html).
 
 ## Running benchmarks
 

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -93,7 +93,7 @@ if [[ "$ARG1" != "--skip-build" ]]; then
 	# echo "Generating .NET glue."
 	# bin/godot.linuxbsd.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue
 	# echo "Building .NET assemblies."
-	# # https://docs.godotengine.org/en/stable/contributing/development/compiling/compiling_with_dotnet.html#nuget-packages
+	# # https://docs.godotengine.org/en/stable/engine_details/development/compiling/compiling_with_dotnet.html#nuget-packages
 	# mkdir -p "$HOME/MyLocalNugetSource"
 	# # Source may already exist, so allow failure for the command below.
 	# dotnet nuget add source "$HOME/MyLocalNugetSource" --name MyLocalNugetSource || true


### PR DESCRIPTION
Follow-up of https://github.com/godotengine/godot-docs/pull/11188.

The contents have already been copied to the contributing docs: https://contributing.godotengine.org/en/latest/other/benchmarks.html