### PR TITLE
Add godot 4.5 release date to graphs.

### DIFF
--- a/web/static/graphs.js
+++ b/web/static/graphs.js
@@ -13,6 +13,7 @@ function getAllowedMetrics() {
 const godotReleaseDates = {
 	"2024-08-15": "4.3",
 	"2025-03-03": "4.4",
+	"2025-09-15": "4.5",
 };
 
 // Themes extracted using https://stackoverflow.com/questions/71721049/react-plotly-js-apply-dark-plotly-dark-theme


### PR DESCRIPTION
This will add a vertical line where Godot 4.5 was released.

Unfortunately, builds are still failing, so changes aren't reaching https://benchmarks.godotengine.org anyway. But it will be there when it's fixed.