### PR TITLE
Add OS distribution, C/C++ compiler and linker version to benchmark results

### DIFF
--- a/web/layouts/benchmark/single.html
+++ b/web/layouts/benchmark/single.html
@@ -44,7 +44,33 @@
   </tr>
   <tr>
     <td>Operating system</td>
-    <td>Fedora 40 64-bit</td>
+    <td>
+      {{ if $benchmark.system.os }}
+      {{ $benchmark.system.os }}
+      {{ else }}
+      (unknown)
+      {{ end }}
+    </td>
+  </tr>
+  <tr>
+    <td>C/C++ compiler</td>
+    <td>
+      {{ if $benchmark.system.compiler }}
+      {{ $benchmark.system.compiler }}
+      {{ else }}
+      (unknown)
+      {{ end }}
+    </td>
+  </tr>
+  <tr>
+    <td>C/C++ linker</td>
+    <td>
+      {{ if $benchmark.system.linker }}
+      {{ $benchmark.system.linker }}
+      {{ else }}
+      (unknown)
+      {{ end }}
+    </td>
   </tr>
 </table>
 

--- a/web/layouts/index.html
+++ b/web/layouts/index.html
@@ -87,7 +87,7 @@
     </tr>
     <tr>
       <td>Operating system</td>
-      <td>Fedora 42 x86_64</td>
+      <td>Fedora Linux 42</td>
     </tr>
   </table>
   <p>


### PR DESCRIPTION
This information is now stored for new benchmarks.

Note that it's calculated at run-time using the same compiler/linker as used in production, since this information isn't stored at compile-time in the binary.

Currently, existing benchmarks will display `Linux` for the OS and `(unknown)` for the compiler/linker. I could modify the existing result files to update the distro/compiler/linker information based on the run dates (to roughly match the latest Fedora version available at the time, as well as GCC/LD from its repositories). That said, doing so would be an approximation so it may be best to leave things as-is, especially since I don't remember the *exact* dates at which I upgraded the server.

- This closes https://github.com/godotengine/godot-benchmarks/issues/112
  and closes https://github.com/godotengine/godot-benchmarks/issues/113.

## Preview

<img width="825" height="234" alt="Screenshot_20251003_164730" src="https://github.com/user-attachments/assets/e50c0c3f-e7f8-4b01-8530-c61a993e94c2" />

