### PR TITLE
Add C++ GDExtension benchmarks for StringName and NodePath

### DIFF
--- a/gdextension/src/benchmarks/node_path.cpp
+++ b/gdextension/src/benchmarks/node_path.cpp
@@ -1,0 +1,36 @@
+#include "node_path.h"
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+void CPPBenchmarkNodePath::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("benchmark_create_same"), &CPPBenchmarkNodePath::benchmark_create_same);
+	ClassDB::bind_method(D_METHOD("benchmark_create_unique"), &CPPBenchmarkNodePath::benchmark_create_unique);
+	ClassDB::bind_method(D_METHOD("benchmark_copy"), &CPPBenchmarkNodePath::benchmark_copy);
+}
+
+void CPPBenchmarkNodePath::benchmark_create_same() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		NodePath np("Node/Child/GrandChild");
+		// np is destroyed here, decrementing the refcount.
+	}
+}
+
+void CPPBenchmarkNodePath::benchmark_create_unique() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		NodePath np(String("Node/Child/") + String::num_int64(i));
+		// np is destroyed here, removing its components from the hash table.
+	}
+}
+
+void CPPBenchmarkNodePath::benchmark_copy() {
+	NodePath original("Node/Child/GrandChild");
+	for (unsigned int i = 0; i < iterations; ++i) {
+		NodePath copy(original);
+	}
+}
+
+CPPBenchmarkNodePath::CPPBenchmarkNodePath() {}
+
+CPPBenchmarkNodePath::~CPPBenchmarkNodePath() {}

--- a/gdextension/src/benchmarks/node_path.h
+++ b/gdextension/src/benchmarks/node_path.h
@@ -1,0 +1,27 @@
+#ifndef CPP_BENCHMARK_NODE_PATH_H
+#define CPP_BENCHMARK_NODE_PATH_H
+
+#include "../cppbenchmark.h"
+
+namespace godot {
+
+class CPPBenchmarkNodePath : public CPPBenchmark {
+	GDCLASS(CPPBenchmarkNodePath, CPPBenchmark)
+
+protected:
+	static void _bind_methods();
+
+public:
+	unsigned int iterations = 1000000;
+
+	void benchmark_create_same();
+	void benchmark_create_unique();
+	void benchmark_copy();
+
+	CPPBenchmarkNodePath();
+	~CPPBenchmarkNodePath();
+};
+
+} // namespace godot
+
+#endif

--- a/gdextension/src/benchmarks/string_name.cpp
+++ b/gdextension/src/benchmarks/string_name.cpp
@@ -1,0 +1,46 @@
+#include "string_name.h"
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+void CPPBenchmarkStringName::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("benchmark_create_same"), &CPPBenchmarkStringName::benchmark_create_same);
+	ClassDB::bind_method(D_METHOD("benchmark_create_unique"), &CPPBenchmarkStringName::benchmark_create_unique);
+	ClassDB::bind_method(D_METHOD("benchmark_copy"), &CPPBenchmarkStringName::benchmark_copy);
+	ClassDB::bind_method(D_METHOD("benchmark_compare"), &CPPBenchmarkStringName::benchmark_compare);
+}
+
+void CPPBenchmarkStringName::benchmark_create_same() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		StringName sn("Godot");
+		// sn is destroyed here, decrementing the refcount.
+	}
+}
+
+void CPPBenchmarkStringName::benchmark_create_unique() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		StringName sn(String("Godot") + String::num_int64(i));
+		// sn is destroyed here, removing it from the hash table.
+	}
+}
+
+void CPPBenchmarkStringName::benchmark_copy() {
+	StringName original("Godot");
+	for (unsigned int i = 0; i < iterations; ++i) {
+		StringName copy(original);
+	}
+}
+
+void CPPBenchmarkStringName::benchmark_compare() {
+	StringName a("Godot");
+	StringName b("Godot");
+	bool result = false;
+	for (unsigned int i = 0; i < iterations; ++i) {
+		result = (a == b);
+	}
+}
+
+CPPBenchmarkStringName::CPPBenchmarkStringName() {}
+
+CPPBenchmarkStringName::~CPPBenchmarkStringName() {}

--- a/gdextension/src/benchmarks/string_name.h
+++ b/gdextension/src/benchmarks/string_name.h
@@ -1,0 +1,28 @@
+#ifndef CPP_BENCHMARK_STRING_NAME_H
+#define CPP_BENCHMARK_STRING_NAME_H
+
+#include "../cppbenchmark.h"
+
+namespace godot {
+
+class CPPBenchmarkStringName : public CPPBenchmark {
+	GDCLASS(CPPBenchmarkStringName, CPPBenchmark)
+
+protected:
+	static void _bind_methods();
+
+public:
+	unsigned int iterations = 1000000;
+
+	void benchmark_create_same();
+	void benchmark_create_unique();
+	void benchmark_copy();
+	void benchmark_compare();
+
+	CPPBenchmarkStringName();
+	~CPPBenchmarkStringName();
+};
+
+} // namespace godot
+
+#endif

--- a/gdextension/src/register_types.cpp
+++ b/gdextension/src/register_types.cpp
@@ -10,10 +10,12 @@
 #include "benchmarks/mandelbrot_set.h"
 #include "benchmarks/merkle_trees.h"
 #include "benchmarks/nbody.h"
+#include "benchmarks/node_path.h"
 #include "benchmarks/spectral_norm.h"
 #include "benchmarks/string_checksum.h"
 #include "benchmarks/string_format.h"
 #include "benchmarks/string_manipulation.h"
+#include "benchmarks/string_name.h"
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
@@ -37,10 +39,12 @@ void initialize_benchmark_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_CLASS(CPPBenchmarkMandelbrotSet);
 	GDREGISTER_CLASS(CPPBenchmarkMerkleTrees);
 	GDREGISTER_CLASS(CPPBenchmarkNbody);
+	GDREGISTER_CLASS(CPPBenchmarkNodePath);
 	GDREGISTER_CLASS(CPPBenchmarkSpectralNorm);
 	GDREGISTER_CLASS(CPPBenchmarkStringChecksum);
 	GDREGISTER_CLASS(CPPBenchmarkStringFormat);
 	GDREGISTER_CLASS(CPPBenchmarkStringManipulation);
+	GDREGISTER_CLASS(CPPBenchmarkStringName);
 }
 
 void uninitialize_benchmark_module(ModuleInitializationLevel p_level) {

--- a/manager.gd
+++ b/manager.gd
@@ -12,10 +12,12 @@ const CPP_CLASS_NAMES: Array[StringName] = [
 	&"CPPBenchmarkMandelbrotSet",
 	&"CPPBenchmarkMerkleTrees",
 	&"CPPBenchmarkNbody",
+	&"CPPBenchmarkNodePath",
 	&"CPPBenchmarkSpectralNorm",
 	&"CPPBenchmarkStringChecksum",
 	&"CPPBenchmarkStringFormat",
 	&"CPPBenchmarkStringManipulation",
+	&"CPPBenchmarkStringName",
 ]
 
 class Results:


### PR DESCRIPTION
Contributes to #36

Adds C++ GDExtension benchmarks for `StringName` and `NodePath`, complementing the existing GDScript versions in `benchmarks/core/`.

The C++ versions measure the underlying engine implementation directly without GDScript interpreter overhead, providing cleaner data for regression detection.

## StringName benchmarks
- `create_same` — creates the same StringName 1M times, measuring the hot path (hash table lookup + refcount)
- `create_unique` — creates a unique StringName each iteration, measuring the cold path (hash computation + allocation + table insertion)
- `copy` — copies an existing StringName 1M times, measuring pure refcount overhead
- `compare` — compares two equal StringNames 1M times, confirming pointer equality fast path

## NodePath benchmarks
- `create_same` — creates the same NodePath 1M times, measuring repeated path parsing into StringName components
- `create_unique` — creates a unique NodePath each iteration, measuring parsing + unique StringName insertion
- `copy` — copies an existing NodePath 1M times, measuring pure refcount overhead

## Results (AMD Ryzen 7 5800X, Windows, release build)
| Benchmark | Time (ms) |
|---|---|
| StringName/compare | 2.186 |
| StringName/copy | 9.867 |
| StringName/create_same | 22.7 |
| StringName/create_unique | 245.4 |
| NodePath/copy | 8.823 |
| NodePath/create_same | 464.7 |
| NodePath/create_unique | 619.5 |