### PR TITLE
Add C++ GDExtension benchmarks for Signal emission

### DIFF
--- a/gdextension/src/benchmarks/signal.cpp
+++ b/gdextension/src/benchmarks/signal.cpp
@@ -1,0 +1,64 @@
+#include "signal.h"
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+void CPPBenchmarkSignal::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("benchmark_emission_params_0"), &CPPBenchmarkSignal::benchmark_emission_params_0);
+	ClassDB::bind_method(D_METHOD("benchmark_emission_params_1"), &CPPBenchmarkSignal::benchmark_emission_params_1);
+	ClassDB::bind_method(D_METHOD("benchmark_emission_params_10"), &CPPBenchmarkSignal::benchmark_emission_params_10);
+
+	ClassDB::bind_method(D_METHOD("on_emit"), &CPPBenchmarkSignal::on_emit);
+	ClassDB::bind_method(D_METHOD("on_emit_params_1", "arg1"), &CPPBenchmarkSignal::on_emit_params_1);
+	ClassDB::bind_method(D_METHOD("on_emit_params_10", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7", "arg8", "arg9", "arg10"), &CPPBenchmarkSignal::on_emit_params_10);
+
+	ADD_SIGNAL(MethodInfo("emitter"));
+	ADD_SIGNAL(MethodInfo("emitter_params_1", PropertyInfo(Variant::INT, "arg1")));
+	ADD_SIGNAL(MethodInfo("emitter_params_10",
+			PropertyInfo(Variant::INT, "arg1"),
+			PropertyInfo(Variant::INT, "arg2"),
+			PropertyInfo(Variant::INT, "arg3"),
+			PropertyInfo(Variant::INT, "arg4"),
+			PropertyInfo(Variant::INT, "arg5"),
+			PropertyInfo(Variant::INT, "arg6"),
+			PropertyInfo(Variant::INT, "arg7"),
+			PropertyInfo(Variant::INT, "arg8"),
+			PropertyInfo(Variant::INT, "arg9"),
+			PropertyInfo(Variant::INT, "arg10")));
+}
+
+void CPPBenchmarkSignal::on_emit() {}
+
+void CPPBenchmarkSignal::on_emit_params_1(int arg1) {}
+
+void CPPBenchmarkSignal::on_emit_params_10(int arg1, int arg2, int arg3, int arg4, int arg5,
+		int arg6, int arg7, int arg8, int arg9, int arg10) {}
+
+void CPPBenchmarkSignal::benchmark_emission_params_0() {
+	connect("emitter", callable_mp(this, &CPPBenchmarkSignal::on_emit));
+	for (unsigned int i = 0; i < iterations; ++i) {
+		emit_signal("emitter");
+	}
+	disconnect("emitter", callable_mp(this, &CPPBenchmarkSignal::on_emit));
+}
+
+void CPPBenchmarkSignal::benchmark_emission_params_1() {
+	connect("emitter_params_1", callable_mp(this, &CPPBenchmarkSignal::on_emit_params_1));
+	for (unsigned int i = 0; i < iterations; ++i) {
+		emit_signal("emitter_params_1", i);
+	}
+	disconnect("emitter_params_1", callable_mp(this, &CPPBenchmarkSignal::on_emit_params_1));
+}
+
+void CPPBenchmarkSignal::benchmark_emission_params_10() {
+	connect("emitter_params_10", callable_mp(this, &CPPBenchmarkSignal::on_emit_params_10));
+	for (unsigned int i = 0; i < iterations; ++i) {
+		emit_signal("emitter_params_10", i, i, i, i, i, i, i, i, i, i);
+	}
+	disconnect("emitter_params_10", callable_mp(this, &CPPBenchmarkSignal::on_emit_params_10));
+}
+
+CPPBenchmarkSignal::CPPBenchmarkSignal() {}
+
+CPPBenchmarkSignal::~CPPBenchmarkSignal() {}

--- a/gdextension/src/benchmarks/signal.h
+++ b/gdextension/src/benchmarks/signal.h
@@ -1,0 +1,33 @@
+#ifndef CPP_BENCHMARK_SIGNAL_H
+#define CPP_BENCHMARK_SIGNAL_H
+
+#include "../cppbenchmark.h"
+
+namespace godot {
+
+class CPPBenchmarkSignal : public CPPBenchmark {
+	GDCLASS(CPPBenchmarkSignal, CPPBenchmark)
+
+protected:
+	static void _bind_methods();
+
+private:
+	void on_emit();
+	void on_emit_params_1(int arg1);
+	void on_emit_params_10(int arg1, int arg2, int arg3, int arg4, int arg5,
+			int arg6, int arg7, int arg8, int arg9, int arg10);
+
+public:
+	unsigned int iterations = 1000000;
+
+	void benchmark_emission_params_0();
+	void benchmark_emission_params_1();
+	void benchmark_emission_params_10();
+
+	CPPBenchmarkSignal();
+	~CPPBenchmarkSignal();
+};
+
+} // namespace godot
+
+#endif

--- a/gdextension/src/register_types.cpp
+++ b/gdextension/src/register_types.cpp
@@ -10,6 +10,7 @@
 #include "benchmarks/mandelbrot_set.h"
 #include "benchmarks/merkle_trees.h"
 #include "benchmarks/nbody.h"
+#include "benchmarks/signal.h"
 #include "benchmarks/spectral_norm.h"
 #include "benchmarks/string_checksum.h"
 #include "benchmarks/string_format.h"
@@ -37,6 +38,7 @@ void initialize_benchmark_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_CLASS(CPPBenchmarkMandelbrotSet);
 	GDREGISTER_CLASS(CPPBenchmarkMerkleTrees);
 	GDREGISTER_CLASS(CPPBenchmarkNbody);
+	GDREGISTER_CLASS(CPPBenchmarkSignal);
 	GDREGISTER_CLASS(CPPBenchmarkSpectralNorm);
 	GDREGISTER_CLASS(CPPBenchmarkStringChecksum);
 	GDREGISTER_CLASS(CPPBenchmarkStringFormat);

--- a/manager.gd
+++ b/manager.gd
@@ -12,6 +12,7 @@ const CPP_CLASS_NAMES: Array[StringName] = [
 	&"CPPBenchmarkMandelbrotSet",
 	&"CPPBenchmarkMerkleTrees",
 	&"CPPBenchmarkNbody",
+	&"CPPBenchmarkSignal",
 	&"CPPBenchmarkSpectralNorm",
 	&"CPPBenchmarkStringChecksum",
 	&"CPPBenchmarkStringFormat",


### PR DESCRIPTION
Contributes to #36

Adds C++ GDExtension benchmarks for `Signal` emission, complementing the existing GDScript version in `benchmarks/core/`.

The C++ version measures the underlying signal dispatch implementation directly without GDScript interpreter overhead, providing cleaner data for regression detection.

## Benchmarks
- `emission_params_0` — emits a signal with no arguments 1M times, measuring the baseline cost of lock acquisition, slot lookup, callable copy, and dispatch
- `emission_params_1` — emits a signal with 1 argument 1M times, adding the cost of one Variant construction per iteration
- `emission_params_10` — emits a signal with 10 arguments 1M times, adding the cost of ten Variant constructions per iteration

Each benchmark connects a single receiver before the loop and disconnects after, isolating emission cost from connect/disconnect overhead.

## Results (AMD Ryzen 7 5800X, Windows, release build)
| Benchmark | Time (ms) |
|---|---|
| emission_params_0 | 186.1 |
| emission_params_1 | 216.0 |
| emission_params_10 | 356.8 |