### PR TITLE
Add C++ GDExtension benchmarks for RandomNumberGenerator

### DIFF
--- a/gdextension/src/benchmarks/random_number_generator.cpp
+++ b/gdextension/src/benchmarks/random_number_generator.cpp
@@ -1,0 +1,63 @@
+#include "random_number_generator.h"
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+const uint64_t RANDOM_SEED = 0x60d07;
+
+void CPPBenchmarkRandomNumberGenerator::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("benchmark_randi"), &CPPBenchmarkRandomNumberGenerator::benchmark_randi);
+	ClassDB::bind_method(D_METHOD("benchmark_randf"), &CPPBenchmarkRandomNumberGenerator::benchmark_randf);
+	ClassDB::bind_method(D_METHOD("benchmark_randi_range"), &CPPBenchmarkRandomNumberGenerator::benchmark_randi_range);
+	ClassDB::bind_method(D_METHOD("benchmark_randf_range"), &CPPBenchmarkRandomNumberGenerator::benchmark_randf_range);
+	ClassDB::bind_method(D_METHOD("benchmark_randfn"), &CPPBenchmarkRandomNumberGenerator::benchmark_randfn);
+	ClassDB::bind_method(D_METHOD("benchmark_randomize"), &CPPBenchmarkRandomNumberGenerator::benchmark_randomize);
+}
+
+void CPPBenchmarkRandomNumberGenerator::benchmark_randi() {
+	rng->set_seed(RANDOM_SEED);
+	for (unsigned int i = 0; i < iterations; ++i) {
+		rng->randi();
+	}
+}
+
+void CPPBenchmarkRandomNumberGenerator::benchmark_randf() {
+	rng->set_seed(RANDOM_SEED);
+	for (unsigned int i = 0; i < iterations; ++i) {
+		rng->randf();
+	}
+}
+
+void CPPBenchmarkRandomNumberGenerator::benchmark_randi_range() {
+	rng->set_seed(RANDOM_SEED);
+	for (unsigned int i = 0; i < iterations; ++i) {
+		rng->randi_range(1234, 5678);
+	}
+}
+
+void CPPBenchmarkRandomNumberGenerator::benchmark_randf_range() {
+	rng->set_seed(RANDOM_SEED);
+	for (unsigned int i = 0; i < iterations; ++i) {
+		rng->randf_range(1234.0, 5678.0);
+	}
+}
+
+void CPPBenchmarkRandomNumberGenerator::benchmark_randfn() {
+	rng->set_seed(RANDOM_SEED);
+	for (unsigned int i = 0; i < iterations; ++i) {
+		rng->randfn(10.0, 2.0);
+	}
+}
+
+void CPPBenchmarkRandomNumberGenerator::benchmark_randomize() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		rng->randomize();
+	}
+}
+
+CPPBenchmarkRandomNumberGenerator::CPPBenchmarkRandomNumberGenerator() {
+	rng.instantiate();
+}
+
+CPPBenchmarkRandomNumberGenerator::~CPPBenchmarkRandomNumberGenerator() {}

--- a/gdextension/src/benchmarks/random_number_generator.h
+++ b/gdextension/src/benchmarks/random_number_generator.h
@@ -1,0 +1,34 @@
+#ifndef CPP_BENCHMARK_RANDOM_NUMBER_GENERATOR_H
+#define CPP_BENCHMARK_RANDOM_NUMBER_GENERATOR_H
+
+#include "../cppbenchmark.h"
+#include <godot_cpp/classes/random_number_generator.hpp>
+
+namespace godot {
+
+class CPPBenchmarkRandomNumberGenerator : public CPPBenchmark {
+	GDCLASS(CPPBenchmarkRandomNumberGenerator, CPPBenchmark)
+
+protected:
+	static void _bind_methods();
+
+private:
+	Ref<RandomNumberGenerator> rng;
+
+public:
+	unsigned int iterations = 10000000;
+
+	void benchmark_randi();
+	void benchmark_randf();
+	void benchmark_randi_range();
+	void benchmark_randf_range();
+	void benchmark_randfn();
+	void benchmark_randomize();
+
+	CPPBenchmarkRandomNumberGenerator();
+	~CPPBenchmarkRandomNumberGenerator();
+};
+
+} // namespace godot
+
+#endif

--- a/gdextension/src/register_types.cpp
+++ b/gdextension/src/register_types.cpp
@@ -10,6 +10,7 @@
 #include "benchmarks/mandelbrot_set.h"
 #include "benchmarks/merkle_trees.h"
 #include "benchmarks/nbody.h"
+#include "benchmarks/random_number_generator.h"
 #include "benchmarks/spectral_norm.h"
 #include "benchmarks/string_checksum.h"
 #include "benchmarks/string_format.h"
@@ -37,6 +38,7 @@ void initialize_benchmark_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_CLASS(CPPBenchmarkMandelbrotSet);
 	GDREGISTER_CLASS(CPPBenchmarkMerkleTrees);
 	GDREGISTER_CLASS(CPPBenchmarkNbody);
+	GDREGISTER_CLASS(CPPBenchmarkRandomNumberGenerator);
 	GDREGISTER_CLASS(CPPBenchmarkSpectralNorm);
 	GDREGISTER_CLASS(CPPBenchmarkStringChecksum);
 	GDREGISTER_CLASS(CPPBenchmarkStringFormat);

--- a/manager.gd
+++ b/manager.gd
@@ -12,6 +12,7 @@ const CPP_CLASS_NAMES: Array[StringName] = [
 	&"CPPBenchmarkMandelbrotSet",
 	&"CPPBenchmarkMerkleTrees",
 	&"CPPBenchmarkNbody",
+	&"CPPBenchmarkRandomNumberGenerator",
 	&"CPPBenchmarkSpectralNorm",
 	&"CPPBenchmarkStringChecksum",
 	&"CPPBenchmarkStringFormat",


### PR DESCRIPTION
Contributes to #36

Adds C++ GDExtension benchmarks for `RandomNumberGenerator`, complementing the existing GDScript version in `benchmarks/core/`.

The C++ version measures the underlying PCG algorithm implementation directly without GDScript interpreter overhead, providing cleaner data for regression detection.

## Benchmarks
- `randi` — generates a random integer 10M times, measuring raw PCG output cost
- `randf` — generates a random float 10M times, measuring CLZ-based float construction cost
- `randi_range` — generates a bounded random integer 10M times
- `randf_range` — generates a bounded random float 10M times
- `randfn` — generates a normally distributed float 10M times using Box-Muller transform
- `randomize` — re-seeds from system time 10M times, measuring OS interaction cost

Each benchmark resets the seed to `Manager.RANDOM_SEED` before the loop for reproducibility, matching the GDScript version's behavior.  `randomize` is an exception since it overwrites the seed by design.

## Results (AMD Ryzen 7 5800X, Windows, release build)
| Benchmark | Time (ms) |
|---|---|
| randi | 71.45 |
| randf | 118.7 |
| randi_range | 91.56 |
| randf_range | 151.7 |
| randfn | 396.8 |
| randomize | 693.2 |