### PR TITLE
Add C++ GDExtension benchmarks for Array operations

### DIFF
--- a/gdextension/src/benchmarks/array_ops.cpp
+++ b/gdextension/src/benchmarks/array_ops.cpp
@@ -1,0 +1,52 @@
+#include "array_ops.h"
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+void CPPBenchmarkArrayOps::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("benchmark_reverse"), &CPPBenchmarkArrayOps::benchmark_reverse);
+	ClassDB::bind_method(D_METHOD("benchmark_bsearch"), &CPPBenchmarkArrayOps::benchmark_bsearch);
+	ClassDB::bind_method(D_METHOD("benchmark_append_array"), &CPPBenchmarkArrayOps::benchmark_append_array);
+	ClassDB::bind_method(D_METHOD("benchmark_fill"), &CPPBenchmarkArrayOps::benchmark_fill);
+}
+
+void CPPBenchmarkArrayOps::benchmark_reverse() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		array_10.reverse();
+	}
+}
+
+void CPPBenchmarkArrayOps::benchmark_bsearch() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		int64_t index = array_10.bsearch(array_10[i % array_10.size()], true);
+		ERR_FAIL_COND(index == -1);
+	}
+}
+
+void CPPBenchmarkArrayOps::benchmark_append_array() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		array_100.resize(100);
+		array_100.append_array(array_10);
+	}
+}
+
+void CPPBenchmarkArrayOps::benchmark_fill() {
+	for (unsigned int i = 0; i < iterations; ++i) {
+		array_10.fill(100 + i);
+	}
+}
+
+CPPBenchmarkArrayOps::CPPBenchmarkArrayOps() {
+	array_10.resize(10);
+	for (int64_t i = 0; i < 10; ++i) {
+		array_10[i] = i;
+	}
+
+	array_100.resize(100);
+	for (int64_t i = 0; i < 100; ++i) {
+		array_100[i] = i;
+	}
+}
+
+CPPBenchmarkArrayOps::~CPPBenchmarkArrayOps() {}

--- a/gdextension/src/benchmarks/array_ops.h
+++ b/gdextension/src/benchmarks/array_ops.h
@@ -1,0 +1,32 @@
+#ifndef CPP_BENCHMARK_ARRAY_OPS_H
+#define CPP_BENCHMARK_ARRAY_OPS_H
+
+#include "../cppbenchmark.h"
+
+namespace godot {
+
+class CPPBenchmarkArrayOps : public CPPBenchmark {
+	GDCLASS(CPPBenchmarkArrayOps, CPPBenchmark)
+
+protected:
+	static void _bind_methods();
+
+private:
+	TypedArray<int64_t> array_10;
+	TypedArray<int64_t> array_100;
+
+public:
+	unsigned int iterations = 1000000;
+
+	void benchmark_reverse();
+	void benchmark_bsearch();
+	void benchmark_append_array();
+	void benchmark_fill();
+
+	CPPBenchmarkArrayOps();
+	~CPPBenchmarkArrayOps();
+};
+
+} // namespace godot
+
+#endif

--- a/gdextension/src/register_types.cpp
+++ b/gdextension/src/register_types.cpp
@@ -2,6 +2,7 @@
 
 #include "benchmarks/alloc.h"
 #include "benchmarks/array.h"
+#include "benchmarks/array_ops.h"
 #include "benchmarks/binary_trees.h"
 #include "benchmarks/control.h"
 #include "benchmarks/forloop.h"
@@ -29,6 +30,7 @@ void initialize_benchmark_module(ModuleInitializationLevel p_level) {
 	GDREGISTER_CLASS(CPPBenchmark);
 	GDREGISTER_CLASS(CPPBenchmarkAlloc);
 	GDREGISTER_CLASS(CPPBenchmarkArray);
+	GDREGISTER_CLASS(CPPBenchmarkArrayOps);
 	GDREGISTER_CLASS(CPPBenchmarkBinaryTrees);
 	GDREGISTER_CLASS(CPPBenchmarkControl);
 	GDREGISTER_CLASS(CPPBenchmarkForLoop);

--- a/manager.gd
+++ b/manager.gd
@@ -4,6 +4,7 @@ const RANDOM_SEED := 0x60d07
 const CPP_CLASS_NAMES: Array[StringName] = [
 	&"CPPBenchmarkAlloc",
 	&"CPPBenchmarkArray",
+	&"CPPBenchmarkArrayOps",
 	&"CPPBenchmarkBinaryTrees",
 	&"CPPBenchmarkControl",
 	&"CPPBenchmarkForLoop",


### PR DESCRIPTION
Contributes to #36

Adds C++ GDExtension benchmarks for Array operations, complementing the existing GDScript version in `benchmarks/core/`.

The C++ version measures the underlying array operation implementation directly without GDScript interpreter overhead, providing cleaner data for regression detection.

## Benchmarks
- `reverse` — reverses a 10-element array 1M times
- `bsearch` — binary searches a 10-element sorted array 1M times
- `append_array` — appends a 10-element array onto a 100-element array 1M times
- `fill` — fills a 10-element array with a value 1M times

## Note on append_array
The GDScript version of `benchmark_append_array` does not reset the array between iterations, causing it to grow unboundedly to ~10M elements. This C++ version resets the array to 100 elements each iteration via `resize(100)`, measuring a consistent and repeatable append cost rather than an ever-growing one.

## Results (AMD Ryzen 7 5800X, Windows, release build)
| Benchmark | Time (ms) |
|---|---|
| reverse | 12.84 |
| fill | 38.08 |
| bsearch | 49.83 |
| append_array | 62.48 |