### PR TITLE
Enable C# benchmarks, fix C# List benchmarks, add C# interop benchmark.

### DIFF
--- a/benchmarks/csharp/InteropStructsPerformance.cs
+++ b/benchmarks/csharp/InteropStructsPerformance.cs
@@ -1,0 +1,187 @@
+using Godot;
+using System;
+using Godot.Collections;
+
+public partial class InteropStructsPerformance : Benchmark
+{
+    private ulong frameCount;
+    private ulong elapsed;
+    private ulong firstFrameTime;
+    private ulong averageDrawTime;
+    private ulong peakDrawTime;
+    private ulong peakMemory;
+    private ulong averageMemory;
+    private ulong start;
+
+    private void OnDrawFinish()
+    {
+        var stop = Time.GetTicksMsec();
+        elapsed += stop - start;
+
+        ulong totalMemory = (ulong)GC.GetTotalMemory(false);
+        peakMemory = Math.Max(totalMemory, peakMemory);
+        if (frameCount == 1)
+        {
+            averageMemory = totalMemory;
+        }
+        else
+        {
+            averageMemory = averageMemory * (frameCount - 1) / frameCount + totalMemory / frameCount;
+        }
+
+        averageDrawTime = elapsed / frameCount;
+        peakDrawTime = Math.Max(stop - start, peakDrawTime);
+
+        if (stop - firstFrameTime >= 1000) // output every second
+        {
+            GD.Print($"GC usage: {totalMemory / (1024 * 1024)}Mb ({totalMemory}), average {averageMemory / (1024 * 1024)}Mb ({averageMemory}). Total frames:{frameCount} draw time: {stop - start}ms. average: {averageDrawTime}ms. peak: {peakDrawTime}ms");
+            firstFrameTime = Time.GetTicksMsec();
+        }
+    }
+
+    private void OnDrawStart()
+    {
+        GC.Collect();
+        GC.Collect();
+
+        frameCount++;
+        if (firstFrameTime == 0)
+        {
+            firstFrameTime = Time.GetTicksMsec();
+        }
+
+        start = Time.GetTicksMsec();
+    }
+
+    public Node2D BenchmarkIndexOfEmptyArray()
+    {
+        benchmark_time = 5e6; // 5 seconds
+        test_idle = true;
+
+        Array<int> list = new Array<int>();
+
+        var scene = new CSharpScene(
+            ready: () => {},
+            draw: amount => {
+                OnDrawStart();
+
+                for (var i = 0; i < amount; i++)
+                {
+                    // forces a call to Count when it checks if the list is empty
+                    _ = list.IndexOf(0);
+                }
+
+                OnDrawFinish();
+            },
+            exit: () => {
+                GD.Print($"GC average usage: {averageMemory / (1024 * 1024)}Mb ({averageMemory}). GC peak: {peakMemory / (1024 * 1024)}Mb ({peakMemory}). Average Draw() time: {averageDrawTime}ms. Peak Draw() time: {peakDrawTime}ms");
+            },
+            1_000_000);
+        return scene;
+    }
+
+    public Node2D BenchmarkIndexOfNonEmptyArray()
+    {
+        benchmark_time = 5e6; // 5 seconds
+        test_idle = true;
+
+        Array<int> list = new Array<int>();
+        list.Add(0);
+
+        var scene = new CSharpScene(
+            ready: () => {},
+            draw: amount => {
+                OnDrawStart();
+
+                for (var i = 0; i < amount; i++)
+                {
+                    // does an interop call
+                    _ = list.IndexOf(0);
+                }
+
+                OnDrawFinish();
+            },
+            exit: () => {
+                GD.Print($"GC average usage: {averageMemory / (1024 * 1024)}Mb ({averageMemory}). GC peak: {peakMemory / (1024 * 1024)}Mb ({peakMemory}). Average Draw() time: {averageDrawTime}ms. Peak Draw() time: {peakDrawTime}ms");
+            },
+            1_000_000);
+        return scene;
+    }
+
+}
+
+public partial class CSharpScene : Node2D
+{
+    private readonly Action onReady;
+    private readonly Action<int> onDraw;
+    private readonly Action onExit;
+    private readonly int amount;
+
+
+    public CSharpScene(Action ready, Action<int> draw, Action exit, int amount) : base()
+    {
+        this.onReady = ready;
+        this.onDraw = draw;
+        this.onExit = exit;
+        this.amount = amount;
+    }
+
+    public override void _Ready()
+    {
+        onReady();
+        SetProcess(true);
+    }
+
+    public override void _Process(double delta)
+    {
+        QueueRedraw();
+    }
+
+    public override void _ExitTree()
+    {
+        onExit();
+    }
+
+    public override void _Draw()
+    {
+        onDraw(amount);
+    }
+}
+
+// Potentially useful large and small objects to stress test the gc, not used right now.
+internal partial class LargeGC : RefCounted
+{
+    const int SIZE = 10625; //85 KB
+
+    public double[] d;
+    public SmallGC m_pSmall;
+
+    public LargeGC()
+    {
+        d = new double[SIZE];
+        m_pSmall = null;
+    }
+
+    public virtual void AttachSmallObjects(SmallGC small)
+    {
+        m_pSmall = small;
+    }
+}
+
+internal class SmallGC : RefCounted
+{
+    public LargeGC m_pLarge;
+
+    public SmallGC(int HasLargeObj)
+    {
+        if (HasLargeObj == 1)
+            m_pLarge = new LargeGC();
+        else
+            m_pLarge = null;
+    }
+
+    public virtual void AttachSmallObjects()
+    {
+        m_pLarge.AttachSmallObjects(this);
+    }
+}

--- a/benchmarks/csharp/InteropStructsPerformance.cs.uid
+++ b/benchmarks/csharp/InteropStructsPerformance.cs.uid
@@ -1,0 +1,1 @@
+uid://c8nwvlr1dlvr5

--- a/benchmarks/csharp/List.cs
+++ b/benchmarks/csharp/List.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+using Godot.Collections;
 
 // Similar to GDScript Array benchmarks, but using C# List instead
 
@@ -6,9 +6,16 @@ public partial class List : Benchmark
 {
     private const int ITERATIONS = 2_000_000;
 
+    public void BenchmarkEmptyList()
+    {
+        Array<int> list = new Array<int>();
+        for (int i = 0; i < ITERATIONS; i++)
+        { list.IndexOf(0); }
+    }
+
     public void BenchmarkInt32List()
     {
-        List<int> list = new List<int>();
+        Array<int> list = new Array<int>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add(i); }
@@ -22,7 +29,7 @@ public partial class List : Benchmark
 
     public void BenchmarkInt64List()
     {
-        List<long> list = new List<long>();
+        Array<long> list = new Array<long>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add(i); }
@@ -36,7 +43,7 @@ public partial class List : Benchmark
 
     public void BenchmarkFloat32List()
     {
-        List<float> list = new List<float>();
+        Array<float> list = new Array<float>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add(i); }
@@ -50,7 +57,7 @@ public partial class List : Benchmark
 
     public void BenchmarkFloat64List()
     {
-        List<double> list = new List<double>();
+        Array<double> list = new Array<double>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add(i); }
@@ -64,7 +71,7 @@ public partial class List : Benchmark
 
     public void BenchmarkVector2List()
     {
-        List<Godot.Vector2> list = new List<Godot.Vector2>();
+        Array<Godot.Vector2> list = new Array<Godot.Vector2>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add(new Godot.Vector2(i, i)); }
@@ -78,7 +85,7 @@ public partial class List : Benchmark
 
     public void BenchmarkVector3List()
     {
-        List<Godot.Vector3> list = new List<Godot.Vector3>();
+        Array<Godot.Vector3> list = new Array<Godot.Vector3>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add(new Godot.Vector3(i, i, i)); }
@@ -92,7 +99,7 @@ public partial class List : Benchmark
 
     public void BenchmarkColorList()
     {
-        List<Godot.Color> list = new List<Godot.Color>();
+        Array<Godot.Color> list = new Array<Godot.Color>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add(new Godot.Color(i, i, i, 1.0f)); }
@@ -106,7 +113,7 @@ public partial class List : Benchmark
 
     public void BenchmarkStringList()
     {
-        List<string> list = new List<string>();
+        Array<string> list = new Array<string>();
 
         for(int i = 0; i < ITERATIONS; i++)
         { list.Add("Godot " + i.ToString()); }

--- a/run-benchmarks.sh
+++ b/run-benchmarks.sh
@@ -80,42 +80,36 @@ if [[ "$ARG1" != "--skip-build" ]]; then
 	# within the Godot Git clone.
 	# WARNING: Any untracked and ignored files included in the repository will be removed!
 	BEGIN="$(date +%s%3N)"
-	PEAK_MEMORY_BUILD_DEBUG=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=editor optimize=debug module_mono_enabled=no progress=no debug_symbols=yes -j$(nproc) 2>&1 || true) | tail -1)
+	PEAK_MEMORY_BUILD_DEBUG=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=editor optimize=debug module_mono_enabled=yes progress=no debug_symbols=yes -j$(nproc) 2>&1 || true) | tail -1)
 	END="$(date +%s%3N)"
 	TIME_TO_BUILD_DEBUG="$((END - BEGIN))"
 
 	clear_build_environment
 
 	BEGIN="$(date +%s%3N)"
-	PEAK_MEMORY_BUILD_RELEASE=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=template_release optimize=speed lto=full module_mono_enabled=no progress=no debug_symbols=yes disable_path_overrides=no -j$(nproc) 2>&1 || true) | tail -1)
+	PEAK_MEMORY_BUILD_RELEASE=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=template_release optimize=speed lto=full module_mono_enabled=yes progress=no debug_symbols=yes disable_path_overrides=no -j$(nproc) 2>&1 || true) | tail -1)
 	END="$(date +%s%3N)"
 	TIME_TO_BUILD_RELEASE="$((END - BEGIN))"
 
 	clear_build_environment
 
 	BEGIN="$(date +%s%3N)"
-	PEAK_MEMORY_BUILD_DEV=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=editor dev_build=yes module_mono_enabled=no progress=no debug_symbols=yes -j$(nproc) 2>&1 || true) | tail -1)
+	PEAK_MEMORY_BUILD_DEV=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=editor dev_build=yes module_mono_enabled=yes progress=no debug_symbols=yes -j$(nproc) 2>&1 || true) | tail -1)
 	END="$(date +%s%3N)"
 	TIME_TO_BUILD_DEV="$((END - BEGIN))"
 
 	clear_build_environment
 
 	BEGIN="$(date +%s%3N)"
-	PEAK_MEMORY_BUILD_SCU=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=editor dev_build=yes scu_build=yes module_mono_enabled=no progress=no debug_symbols=yes -j$(nproc) 2>&1 || true) | tail -1)
+	PEAK_MEMORY_BUILD_SCU=$( (/usr/bin/time -f "%M" scons platform=linuxbsd target=editor dev_build=yes scu_build=yes module_mono_enabled=yes progress=no debug_symbols=yes -j$(nproc) 2>&1 || true) | tail -1)
 	END="$(date +%s%3N)"
 	TIME_TO_BUILD_SCU="$((END - BEGIN))"
 
-	# FIXME: C# is disabled because the engine crashes on exit after running benchmarks.
-	#
 	# Generate Mono glue for C# build to work.
-	# echo "Generating .NET glue."
-	# bin/godot.linuxbsd.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue
-	# echo "Building .NET assemblies."
-	# # https://docs.godotengine.org/en/stable/engine_details/development/compiling/compiling_with_dotnet.html#nuget-packages
-	# mkdir -p "$HOME/MyLocalNugetSource"
-	# # Source may already exist, so allow failure for the command below.
-	# dotnet nuget add source "$HOME/MyLocalNugetSource" --name MyLocalNugetSource || true
-	# modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin --push-nupkgs-local "$HOME/MyLocalNugetSource"
+	echo "Generating .NET glue."
+	bin/godot.linuxbsd.editor.x86_64.mono --headless --generate-mono-glue modules/mono/glue
+	echo "Building .NET assemblies."
+	modules/mono/build_scripts/build_assemblies.py --godot-output-dir=./bin
 
 	cd "$DIR"
 else
@@ -130,6 +124,25 @@ else
 	PEAK_MEMORY_BUILD_SCU=1
 fi
 
+# Generate a NuGet config that will pick up the built assemblies in the Godot source
+# dir and cache them in a local .packages dir for use with the project
+cat > NuGet.config <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <!-- use a local package folder so all packages this project needs are cached locally
+    and it's much easier to clean a local folder than the global nuget cache -->
+    <add key="repositorypath" value=".packages" />
+    <add key="globalPackagesFolder" value=".packages" />
+  </config>
+  <packageSources>
+    <!-- Pick up godot nuget packages from this location -->
+    <add key="Local godot build" value="$GODOT_REPO_DIR/bin/GodotSharp/Tools/nupkgs" />
+  </packageSources>
+</configuration>
+EOF
+
+
 # Build the GDExtension that is part of the project.
 # Don't count this as part of the build time benchmark, as it's project-specific.
 pushd "$DIR/gdextension/"
@@ -139,12 +152,12 @@ done
 popd
 
 # Path to the Godot debug binary to run. Used for CPU debug benchmarks.
-GODOT_DEBUG="$GODOT_REPO_DIR/bin/godot.linuxbsd.editor.x86_64"
+GODOT_DEBUG="$GODOT_REPO_DIR/bin/godot.linuxbsd.editor.x86_64.mono"
 
 # Path to the Godot release binary to run. Used for CPU release and GPU benchmarks.
 # The release binary is assumed to be the same commit as the debug build.
 # Things will break if this is not the case.
-GODOT_RELEASE="$GODOT_REPO_DIR/bin/godot.linuxbsd.template_release.x86_64"
+GODOT_RELEASE="$GODOT_REPO_DIR/bin/godot.linuxbsd.template_release.x86_64.mono"
 
 COMMIT_HASH="$($GODOT_DEBUG --version | rev | cut --delimiter="." --field="1" | rev)"
 DATE="$(date +'%Y-%m-%d')"


### PR DESCRIPTION
Fix C# List benchmarks to actually use Godot collections instead of C# base classes.

Add a C# interop benchmark for `IndexOf()` performance on a full scene loop, which can be used to test the impact of https://github.com/godotengine/godot/pull/121334.

Change `run-benchmarks.sh` to use a C#-enabled editor and templates to run the benchmarks with the C# benchmarks also included.